### PR TITLE
DSL Improvements for Property

### DIFF
--- a/bundles/org.eclipse.vorto.core/model/Datatype.ecore
+++ b/bundles/org.eclipse.vorto.core/model/Datatype.ecore
@@ -63,14 +63,21 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Type" eSuperTypes="Model.ecore#//Model"/>
   <eClassifiers xsi:type="ecore:EClass" name="PropertyType"/>
-  <eClassifiers xsi:type="ecore:EClass" name="PropertyAttribute">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="#//PropertyAttributeType"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PropertyAttribute" abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="BooleanPropertyAttribute" eSuperTypes="#//PropertyAttribute">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="#//BooleanPropertyAttributeType"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EEnum" name="PropertyAttributeType">
-    <eLiterals name="MeasurementUnit" value="1" literal="MEASUREMENTUNIT"/>
-    <eLiterals name="Readable" value="2" literal="READABLE"/>
-    <eLiterals name="Writable" value="3" literal="WRITABLE"/>
-    <eLiterals name="Eventable" value="4" literal="EVENTABLE"/>
+  <eClassifiers xsi:type="ecore:EEnum" name="BooleanPropertyAttributeType">
+    <eLiterals name="readable" literal="READABLE"/>
+    <eLiterals name="writable" value="1" literal="WRITABLE"/>
+    <eLiterals name="eventable" value="2" literal="EVENTABLE"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="EnumLiteralPropertyAttribute" eSuperTypes="#//PropertyAttribute">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="#//EnumLiteralPropertyAttributeType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="#//EnumLiteral"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="EnumLiteralPropertyAttributeType">
+    <eLiterals name="measurementUnit"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/BooleanPropertyAttribute.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/BooleanPropertyAttribute.java
@@ -1,0 +1,79 @@
+/**
+ */
+package org.eclipse.vorto.core.api.model.datatype;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Boolean Property Attribute</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * <ul>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#isValue <em>Value</em>}</li>
+ * </ul>
+ * </p>
+ *
+ * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getBooleanPropertyAttribute()
+ * @model
+ * @generated
+ */
+public interface BooleanPropertyAttribute extends PropertyAttribute {
+	/**
+	 * Returns the value of the '<em><b>Type</b></em>' attribute.
+	 * The literals are from the enumeration {@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType
+	 * @see #setType(BooleanPropertyAttributeType)
+	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getBooleanPropertyAttribute_Type()
+	 * @model
+	 * @generated
+	 */
+	BooleanPropertyAttributeType getType();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#getType <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType
+	 * @see #getType()
+	 * @generated
+	 */
+	void setType(BooleanPropertyAttributeType value);
+
+	/**
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(boolean)
+	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getBooleanPropertyAttribute_Value()
+	 * @model
+	 * @generated
+	 */
+	boolean isValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#isValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #isValue()
+	 * @generated
+	 */
+	void setValue(boolean value);
+
+} // BooleanPropertyAttribute

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/BooleanPropertyAttributeType.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/BooleanPropertyAttributeType.java
@@ -1,0 +1,235 @@
+/**
+ */
+package org.eclipse.vorto.core.api.model.datatype;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>Boolean Property Attribute Type</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getBooleanPropertyAttributeType()
+ * @model
+ * @generated
+ */
+public enum BooleanPropertyAttributeType implements Enumerator {
+	/**
+	 * The '<em><b>Readable</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #READABLE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	READABLE(0, "readable", "READABLE"),
+
+	/**
+	 * The '<em><b>Writable</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #WRITABLE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	WRITABLE(1, "writable", "WRITABLE"),
+
+	/**
+	 * The '<em><b>Eventable</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #EVENTABLE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	EVENTABLE(2, "eventable", "EVENTABLE");
+
+	/**
+	 * The '<em><b>Readable</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Readable</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #READABLE
+	 * @model name="readable" literal="READABLE"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int READABLE_VALUE = 0;
+
+	/**
+	 * The '<em><b>Writable</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Writable</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #WRITABLE
+	 * @model name="writable" literal="WRITABLE"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int WRITABLE_VALUE = 1;
+
+	/**
+	 * The '<em><b>Eventable</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Eventable</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #EVENTABLE
+	 * @model name="eventable" literal="EVENTABLE"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int EVENTABLE_VALUE = 2;
+
+	/**
+	 * An array of all the '<em><b>Boolean Property Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final BooleanPropertyAttributeType[] VALUES_ARRAY =
+		new BooleanPropertyAttributeType[] {
+			READABLE,
+			WRITABLE,
+			EVENTABLE,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>Boolean Property Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<BooleanPropertyAttributeType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>Boolean Property Attribute Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static BooleanPropertyAttributeType get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			BooleanPropertyAttributeType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Boolean Property Attribute Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static BooleanPropertyAttributeType getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			BooleanPropertyAttributeType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Boolean Property Attribute Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static BooleanPropertyAttributeType get(int value) {
+		switch (value) {
+			case READABLE_VALUE: return READABLE;
+			case WRITABLE_VALUE: return WRITABLE;
+			case EVENTABLE_VALUE: return EVENTABLE;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private BooleanPropertyAttributeType(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //BooleanPropertyAttributeType

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/DatatypeFactory.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/DatatypeFactory.java
@@ -112,13 +112,22 @@ public interface DatatypeFactory extends EFactory {
 	PropertyType createPropertyType();
 
 	/**
-	 * Returns a new object of class '<em>Property Attribute</em>'.
+	 * Returns a new object of class '<em>Boolean Property Attribute</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return a new object of class '<em>Property Attribute</em>'.
+	 * @return a new object of class '<em>Boolean Property Attribute</em>'.
 	 * @generated
 	 */
-	PropertyAttribute createPropertyAttribute();
+	BooleanPropertyAttribute createBooleanPropertyAttribute();
+
+	/**
+	 * Returns a new object of class '<em>Enum Literal Property Attribute</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Enum Literal Property Attribute</em>'.
+	 * @generated
+	 */
+	EnumLiteralPropertyAttribute createEnumLiteralPropertyAttribute();
 
 	/**
 	 * Returns the package supported by this factory.

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/DatatypePackage.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/DatatypePackage.java
@@ -591,32 +591,14 @@ public interface DatatypePackage extends EPackage {
 	int ENUM_LITERAL_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl <em>Property Attribute</em>}' class.
+	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute <em>Property Attribute</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl
+	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttribute
 	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getPropertyAttribute()
 	 * @generated
 	 */
 	int PROPERTY_ATTRIBUTE = 10;
-
-	/**
-	 * The feature id for the '<em><b>Type</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PROPERTY_ATTRIBUTE__TYPE = 0;
-
-	/**
-	 * The feature id for the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PROPERTY_ATTRIBUTE__VALUE = 1;
 
 	/**
 	 * The number of structural features of the '<em>Property Attribute</em>' class.
@@ -625,7 +607,81 @@ public interface DatatypePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROPERTY_ATTRIBUTE_FEATURE_COUNT = 2;
+	int PROPERTY_ATTRIBUTE_FEATURE_COUNT = 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl <em>Boolean Property Attribute</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getBooleanPropertyAttribute()
+	 * @generated
+	 */
+	int BOOLEAN_PROPERTY_ATTRIBUTE = 11;
+
+	/**
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BOOLEAN_PROPERTY_ATTRIBUTE__TYPE = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 0;
+
+	/**
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BOOLEAN_PROPERTY_ATTRIBUTE__VALUE = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of structural features of the '<em>Boolean Property Attribute</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BOOLEAN_PROPERTY_ATTRIBUTE_FEATURE_COUNT = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 2;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl <em>Enum Literal Property Attribute</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getEnumLiteralPropertyAttribute()
+	 * @generated
+	 */
+	int ENUM_LITERAL_PROPERTY_ATTRIBUTE = 12;
+
+	/**
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 0;
+
+	/**
+	 * The feature id for the '<em><b>Value</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of structural features of the '<em>Enum Literal Property Attribute</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ENUM_LITERAL_PROPERTY_ATTRIBUTE_FEATURE_COUNT = PROPERTY_ATTRIBUTE_FEATURE_COUNT + 2;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.PrimitiveType <em>Primitive Type</em>}' enum.
@@ -635,7 +691,7 @@ public interface DatatypePackage extends EPackage {
 	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getPrimitiveType()
 	 * @generated
 	 */
-	int PRIMITIVE_TYPE = 11;
+	int PRIMITIVE_TYPE = 13;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.ConstraintIntervalType <em>Constraint Interval Type</em>}' enum.
@@ -645,19 +701,28 @@ public interface DatatypePackage extends EPackage {
 	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getConstraintIntervalType()
 	 * @generated
 	 */
-	int CONSTRAINT_INTERVAL_TYPE = 12;
+	int CONSTRAINT_INTERVAL_TYPE = 14;
 
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType <em>Property Attribute Type</em>}' enum.
+	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType <em>Boolean Property Attribute Type</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType
-	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getPropertyAttributeType()
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getBooleanPropertyAttributeType()
 	 * @generated
 	 */
-	int PROPERTY_ATTRIBUTE_TYPE = 13;
+	int BOOLEAN_PROPERTY_ATTRIBUTE_TYPE = 15;
 
+	/**
+	 * The meta object id for the '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType <em>Enum Literal Property Attribute Type</em>}' enum.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType
+	 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getEnumLiteralPropertyAttributeType()
+	 * @generated
+	 */
+	int ENUM_LITERAL_PROPERTY_ATTRIBUTE_TYPE = 16;
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.vorto.core.api.model.datatype.Entity <em>Entity</em>}'.
@@ -957,26 +1022,68 @@ public interface DatatypePackage extends EPackage {
 	EClass getPropertyAttribute();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getType <em>Type</em>}'.
+	 * Returns the meta object for class '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute <em>Boolean Property Attribute</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Boolean Property Attribute</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute
+	 * @generated
+	 */
+	EClass getBooleanPropertyAttribute();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#getType <em>Type</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the meta object for the attribute '<em>Type</em>'.
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getType()
-	 * @see #getPropertyAttribute()
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#getType()
+	 * @see #getBooleanPropertyAttribute()
 	 * @generated
 	 */
-	EAttribute getPropertyAttribute_Type();
+	EAttribute getBooleanPropertyAttribute_Type();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getValue <em>Value</em>}'.
+	 * Returns the meta object for the attribute '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#isValue <em>Value</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the meta object for the attribute '<em>Value</em>'.
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getValue()
-	 * @see #getPropertyAttribute()
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute#isValue()
+	 * @see #getBooleanPropertyAttribute()
 	 * @generated
 	 */
-	EAttribute getPropertyAttribute_Value();
+	EAttribute getBooleanPropertyAttribute_Value();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute <em>Enum Literal Property Attribute</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Enum Literal Property Attribute</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute
+	 * @generated
+	 */
+	EClass getEnumLiteralPropertyAttribute();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getType <em>Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Type</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getType()
+	 * @see #getEnumLiteralPropertyAttribute()
+	 * @generated
+	 */
+	EAttribute getEnumLiteralPropertyAttribute_Type();
+
+	/**
+	 * Returns the meta object for the reference '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the reference '<em>Value</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getValue()
+	 * @see #getEnumLiteralPropertyAttribute()
+	 * @generated
+	 */
+	EReference getEnumLiteralPropertyAttribute_Value();
 
 	/**
 	 * Returns the meta object for enum '{@link org.eclipse.vorto.core.api.model.datatype.PrimitiveType <em>Primitive Type</em>}'.
@@ -999,14 +1106,24 @@ public interface DatatypePackage extends EPackage {
 	EEnum getConstraintIntervalType();
 
 	/**
-	 * Returns the meta object for enum '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType <em>Property Attribute Type</em>}'.
+	 * Returns the meta object for enum '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType <em>Boolean Property Attribute Type</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for enum '<em>Property Attribute Type</em>'.
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType
+	 * @return the meta object for enum '<em>Boolean Property Attribute Type</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType
 	 * @generated
 	 */
-	EEnum getPropertyAttributeType();
+	EEnum getBooleanPropertyAttributeType();
+
+	/**
+	 * Returns the meta object for enum '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType <em>Enum Literal Property Attribute Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for enum '<em>Enum Literal Property Attribute Type</em>'.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType
+	 * @generated
+	 */
+	EEnum getEnumLiteralPropertyAttributeType();
 
 	/**
 	 * Returns the factory that creates the instances of the model.
@@ -1267,14 +1384,24 @@ public interface DatatypePackage extends EPackage {
 		EClass PROPERTY_TYPE = eINSTANCE.getPropertyType();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl <em>Property Attribute</em>}' class.
+		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute <em>Property Attribute</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @see org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl
+		 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttribute
 		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getPropertyAttribute()
 		 * @generated
 		 */
 		EClass PROPERTY_ATTRIBUTE = eINSTANCE.getPropertyAttribute();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl <em>Boolean Property Attribute</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getBooleanPropertyAttribute()
+		 * @generated
+		 */
+		EClass BOOLEAN_PROPERTY_ATTRIBUTE = eINSTANCE.getBooleanPropertyAttribute();
 
 		/**
 		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
@@ -1282,7 +1409,7 @@ public interface DatatypePackage extends EPackage {
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EAttribute PROPERTY_ATTRIBUTE__TYPE = eINSTANCE.getPropertyAttribute_Type();
+		EAttribute BOOLEAN_PROPERTY_ATTRIBUTE__TYPE = eINSTANCE.getBooleanPropertyAttribute_Type();
 
 		/**
 		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
@@ -1290,7 +1417,33 @@ public interface DatatypePackage extends EPackage {
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EAttribute PROPERTY_ATTRIBUTE__VALUE = eINSTANCE.getPropertyAttribute_Value();
+		EAttribute BOOLEAN_PROPERTY_ATTRIBUTE__VALUE = eINSTANCE.getBooleanPropertyAttribute_Value();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl <em>Enum Literal Property Attribute</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getEnumLiteralPropertyAttribute()
+		 * @generated
+		 */
+		EClass ENUM_LITERAL_PROPERTY_ATTRIBUTE = eINSTANCE.getEnumLiteralPropertyAttribute();
+
+		/**
+		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE = eINSTANCE.getEnumLiteralPropertyAttribute_Type();
+
+		/**
+		 * The meta object literal for the '<em><b>Value</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE = eINSTANCE.getEnumLiteralPropertyAttribute_Value();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.PrimitiveType <em>Primitive Type</em>}' enum.
@@ -1313,14 +1466,24 @@ public interface DatatypePackage extends EPackage {
 		EEnum CONSTRAINT_INTERVAL_TYPE = eINSTANCE.getConstraintIntervalType();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType <em>Property Attribute Type</em>}' enum.
+		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType <em>Boolean Property Attribute Type</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType
-		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getPropertyAttributeType()
+		 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getBooleanPropertyAttributeType()
 		 * @generated
 		 */
-		EEnum PROPERTY_ATTRIBUTE_TYPE = eINSTANCE.getPropertyAttributeType();
+		EEnum BOOLEAN_PROPERTY_ATTRIBUTE_TYPE = eINSTANCE.getBooleanPropertyAttributeType();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType <em>Enum Literal Property Attribute Type</em>}' enum.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType
+		 * @see org.eclipse.vorto.core.api.model.datatype.impl.DatatypePackageImpl#getEnumLiteralPropertyAttributeType()
+		 * @generated
+		 */
+		EEnum ENUM_LITERAL_PROPERTY_ATTRIBUTE_TYPE = eINSTANCE.getEnumLiteralPropertyAttributeType();
 
 	}
 

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/EnumLiteralPropertyAttribute.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/EnumLiteralPropertyAttribute.java
@@ -1,0 +1,79 @@
+/**
+ */
+package org.eclipse.vorto.core.api.model.datatype;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Enum Literal Property Attribute</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * <ul>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getValue <em>Value</em>}</li>
+ * </ul>
+ * </p>
+ *
+ * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getEnumLiteralPropertyAttribute()
+ * @model
+ * @generated
+ */
+public interface EnumLiteralPropertyAttribute extends PropertyAttribute {
+	/**
+	 * Returns the value of the '<em><b>Type</b></em>' attribute.
+	 * The literals are from the enumeration {@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType
+	 * @see #setType(EnumLiteralPropertyAttributeType)
+	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getEnumLiteralPropertyAttribute_Type()
+	 * @model
+	 * @generated
+	 */
+	EnumLiteralPropertyAttributeType getType();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getType <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType
+	 * @see #getType()
+	 * @generated
+	 */
+	void setType(EnumLiteralPropertyAttributeType value);
+
+	/**
+	 * Returns the value of the '<em><b>Value</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Value</em>' reference isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Value</em>' reference.
+	 * @see #setValue(EnumLiteral)
+	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getEnumLiteralPropertyAttribute_Value()
+	 * @model
+	 * @generated
+	 */
+	EnumLiteral getValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute#getValue <em>Value</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Value</em>' reference.
+	 * @see #getValue()
+	 * @generated
+	 */
+	void setValue(EnumLiteral value);
+
+} // EnumLiteralPropertyAttribute

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/EnumLiteralPropertyAttributeType.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/EnumLiteralPropertyAttributeType.java
@@ -1,0 +1,181 @@
+/**
+ */
+package org.eclipse.vorto.core.api.model.datatype;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>Enum Literal Property Attribute Type</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getEnumLiteralPropertyAttributeType()
+ * @model
+ * @generated
+ */
+public enum EnumLiteralPropertyAttributeType implements Enumerator {
+	/**
+	 * The '<em><b>Measurement Unit</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #MEASUREMENT_UNIT_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	MEASUREMENT_UNIT(0, "measurementUnit", "measurementUnit");
+
+	/**
+	 * The '<em><b>Measurement Unit</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Measurement Unit</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #MEASUREMENT_UNIT
+	 * @model name="measurementUnit"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int MEASUREMENT_UNIT_VALUE = 0;
+
+	/**
+	 * An array of all the '<em><b>Enum Literal Property Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final EnumLiteralPropertyAttributeType[] VALUES_ARRAY =
+		new EnumLiteralPropertyAttributeType[] {
+			MEASUREMENT_UNIT,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>Enum Literal Property Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<EnumLiteralPropertyAttributeType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>Enum Literal Property Attribute Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static EnumLiteralPropertyAttributeType get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			EnumLiteralPropertyAttributeType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Enum Literal Property Attribute Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static EnumLiteralPropertyAttributeType getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			EnumLiteralPropertyAttributeType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Enum Literal Property Attribute Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static EnumLiteralPropertyAttributeType get(int value) {
+		switch (value) {
+			case MEASUREMENT_UNIT_VALUE: return MEASUREMENT_UNIT;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EnumLiteralPropertyAttributeType(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //EnumLiteralPropertyAttributeType

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/PropertyAttribute.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/PropertyAttribute.java
@@ -9,72 +9,11 @@ import org.eclipse.emf.ecore.EObject;
  * A representation of the model object '<em><b>Property Attribute</b></em>'.
  * <!-- end-user-doc -->
  *
- * <p>
- * The following features are supported:
- * <ul>
- *   <li>{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getType <em>Type</em>}</li>
- *   <li>{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getValue <em>Value</em>}</li>
- * </ul>
- * </p>
  *
  * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getPropertyAttribute()
- * @model
+ * @model interface="true" abstract="true"
  * @generated
  */
 public interface PropertyAttribute extends EObject {
-	/**
-	 * Returns the value of the '<em><b>Type</b></em>' attribute.
-	 * The literals are from the enumeration {@link org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType}.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Type</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Type</em>' attribute.
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType
-	 * @see #setType(PropertyAttributeType)
-	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getPropertyAttribute_Type()
-	 * @model
-	 * @generated
-	 */
-	PropertyAttributeType getType();
-
-	/**
-	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getType <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Type</em>' attribute.
-	 * @see org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType
-	 * @see #getType()
-	 * @generated
-	 */
-	void setType(PropertyAttributeType value);
-
-	/**
-	 * Returns the value of the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Value</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Value</em>' attribute.
-	 * @see #setValue(String)
-	 * @see org.eclipse.vorto.core.api.model.datatype.DatatypePackage#getPropertyAttribute_Value()
-	 * @model
-	 * @generated
-	 */
-	String getValue();
-
-	/**
-	 * Sets the value of the '{@link org.eclipse.vorto.core.api.model.datatype.PropertyAttribute#getValue <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Value</em>' attribute.
-	 * @see #getValue()
-	 * @generated
-	 */
-	void setValue(String value);
 
 } // PropertyAttribute

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/BooleanPropertyAttributeImpl.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/BooleanPropertyAttributeImpl.java
@@ -1,0 +1,218 @@
+/**
+ */
+package org.eclipse.vorto.core.api.model.datatype.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType;
+import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Boolean Property Attribute</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * <ul>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.BooleanPropertyAttributeImpl#isValue <em>Value</em>}</li>
+ * </ul>
+ * </p>
+ *
+ * @generated
+ */
+public class BooleanPropertyAttributeImpl extends MinimalEObjectImpl.Container implements BooleanPropertyAttribute {
+	/**
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final BooleanPropertyAttributeType TYPE_EDEFAULT = BooleanPropertyAttributeType.READABLE;
+
+	/**
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected BooleanPropertyAttributeType type = TYPE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean VALUE_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean value = VALUE_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected BooleanPropertyAttributeImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return DatatypePackage.Literals.BOOLEAN_PROPERTY_ATTRIBUTE;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public BooleanPropertyAttributeType getType() {
+		return type;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setType(BooleanPropertyAttributeType newType) {
+		BooleanPropertyAttributeType oldType = type;
+		type = newType == null ? TYPE_EDEFAULT : newType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__TYPE, oldType, type));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean isValue() {
+		return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setValue(boolean newValue) {
+		boolean oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__VALUE, oldValue, value));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__TYPE:
+				return getType();
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__VALUE:
+				return isValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__TYPE:
+				setType((BooleanPropertyAttributeType)newValue);
+				return;
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__VALUE:
+				setValue((Boolean)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__TYPE:
+				setType(TYPE_EDEFAULT);
+				return;
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__TYPE:
+				return type != TYPE_EDEFAULT;
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE__VALUE:
+				return value != VALUE_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (type: ");
+		result.append(type);
+		result.append(", value: ");
+		result.append(value);
+		result.append(')');
+		return result.toString();
+	}
+
+} //BooleanPropertyAttributeImpl

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/DatatypeFactoryImpl.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/DatatypeFactoryImpl.java
@@ -11,12 +11,16 @@ import org.eclipse.emf.ecore.impl.EFactoryImpl;
 
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType;
 import org.eclipse.vorto.core.api.model.datatype.Constraint;
 import org.eclipse.vorto.core.api.model.datatype.ConstraintIntervalType;
 import org.eclipse.vorto.core.api.model.datatype.DatatypeFactory;
 import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
 import org.eclipse.vorto.core.api.model.datatype.Entity;
 import org.eclipse.vorto.core.api.model.datatype.EnumLiteral;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType;
 import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType;
 import org.eclipse.vorto.core.api.model.datatype.Presence;
 import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType;
@@ -81,7 +85,8 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 			case DatatypePackage.ENUM_LITERAL: return createEnumLiteral();
 			case DatatypePackage.TYPE: return createType();
 			case DatatypePackage.PROPERTY_TYPE: return createPropertyType();
-			case DatatypePackage.PROPERTY_ATTRIBUTE: return createPropertyAttribute();
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE: return createBooleanPropertyAttribute();
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE: return createEnumLiteralPropertyAttribute();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -99,8 +104,10 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 				return createPrimitiveTypeFromString(eDataType, initialValue);
 			case DatatypePackage.CONSTRAINT_INTERVAL_TYPE:
 				return createConstraintIntervalTypeFromString(eDataType, initialValue);
-			case DatatypePackage.PROPERTY_ATTRIBUTE_TYPE:
-				return createPropertyAttributeTypeFromString(eDataType, initialValue);
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE_TYPE:
+				return createBooleanPropertyAttributeTypeFromString(eDataType, initialValue);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE_TYPE:
+				return createEnumLiteralPropertyAttributeTypeFromString(eDataType, initialValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -118,8 +125,10 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 				return convertPrimitiveTypeToString(eDataType, instanceValue);
 			case DatatypePackage.CONSTRAINT_INTERVAL_TYPE:
 				return convertConstraintIntervalTypeToString(eDataType, instanceValue);
-			case DatatypePackage.PROPERTY_ATTRIBUTE_TYPE:
-				return convertPropertyAttributeTypeToString(eDataType, instanceValue);
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE_TYPE:
+				return convertBooleanPropertyAttributeTypeToString(eDataType, instanceValue);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE_TYPE:
+				return convertEnumLiteralPropertyAttributeTypeToString(eDataType, instanceValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -230,9 +239,19 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public PropertyAttribute createPropertyAttribute() {
-		PropertyAttributeImpl propertyAttribute = new PropertyAttributeImpl();
-		return propertyAttribute;
+	public BooleanPropertyAttribute createBooleanPropertyAttribute() {
+		BooleanPropertyAttributeImpl booleanPropertyAttribute = new BooleanPropertyAttributeImpl();
+		return booleanPropertyAttribute;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EnumLiteralPropertyAttribute createEnumLiteralPropertyAttribute() {
+		EnumLiteralPropertyAttributeImpl enumLiteralPropertyAttribute = new EnumLiteralPropertyAttributeImpl();
+		return enumLiteralPropertyAttribute;
 	}
 
 	/**
@@ -280,8 +299,8 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public PropertyAttributeType createPropertyAttributeTypeFromString(EDataType eDataType, String initialValue) {
-		PropertyAttributeType result = PropertyAttributeType.get(initialValue);
+	public BooleanPropertyAttributeType createBooleanPropertyAttributeTypeFromString(EDataType eDataType, String initialValue) {
+		BooleanPropertyAttributeType result = BooleanPropertyAttributeType.get(initialValue);
 		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
@@ -291,7 +310,27 @@ public class DatatypeFactoryImpl extends EFactoryImpl implements DatatypeFactory
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public String convertPropertyAttributeTypeToString(EDataType eDataType, Object instanceValue) {
+	public String convertBooleanPropertyAttributeTypeToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EnumLiteralPropertyAttributeType createEnumLiteralPropertyAttributeTypeFromString(EDataType eDataType, String initialValue) {
+		EnumLiteralPropertyAttributeType result = EnumLiteralPropertyAttributeType.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertEnumLiteralPropertyAttributeTypeToString(EDataType eDataType, Object instanceValue) {
 		return instanceValue == null ? null : instanceValue.toString();
 	}
 

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/DatatypePackageImpl.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/DatatypePackageImpl.java
@@ -10,12 +10,16 @@ import org.eclipse.emf.ecore.EReference;
 
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttributeType;
 import org.eclipse.vorto.core.api.model.datatype.Constraint;
 import org.eclipse.vorto.core.api.model.datatype.ConstraintIntervalType;
 import org.eclipse.vorto.core.api.model.datatype.DatatypeFactory;
 import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
 import org.eclipse.vorto.core.api.model.datatype.Entity;
 import org.eclipse.vorto.core.api.model.datatype.EnumLiteral;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType;
 import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType;
 import org.eclipse.vorto.core.api.model.datatype.Presence;
 import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType;
@@ -119,6 +123,20 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	private EClass booleanPropertyAttributeEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass enumLiteralPropertyAttributeEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	private EEnum primitiveTypeEEnum = null;
 
 	/**
@@ -133,7 +151,14 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	private EEnum propertyAttributeTypeEEnum = null;
+	private EEnum booleanPropertyAttributeTypeEEnum = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EEnum enumLiteralPropertyAttributeTypeEEnum = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -458,8 +483,8 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getPropertyAttribute_Type() {
-		return (EAttribute)propertyAttributeEClass.getEStructuralFeatures().get(0);
+	public EClass getBooleanPropertyAttribute() {
+		return booleanPropertyAttributeEClass;
 	}
 
 	/**
@@ -467,8 +492,44 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getPropertyAttribute_Value() {
-		return (EAttribute)propertyAttributeEClass.getEStructuralFeatures().get(1);
+	public EAttribute getBooleanPropertyAttribute_Type() {
+		return (EAttribute)booleanPropertyAttributeEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getBooleanPropertyAttribute_Value() {
+		return (EAttribute)booleanPropertyAttributeEClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getEnumLiteralPropertyAttribute() {
+		return enumLiteralPropertyAttributeEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getEnumLiteralPropertyAttribute_Type() {
+		return (EAttribute)enumLiteralPropertyAttributeEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EReference getEnumLiteralPropertyAttribute_Value() {
+		return (EReference)enumLiteralPropertyAttributeEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
@@ -494,8 +555,17 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EEnum getPropertyAttributeType() {
-		return propertyAttributeTypeEEnum;
+	public EEnum getBooleanPropertyAttributeType() {
+		return booleanPropertyAttributeTypeEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EEnum getEnumLiteralPropertyAttributeType() {
+		return enumLiteralPropertyAttributeTypeEEnum;
 	}
 
 	/**
@@ -564,13 +634,20 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 		propertyTypeEClass = createEClass(PROPERTY_TYPE);
 
 		propertyAttributeEClass = createEClass(PROPERTY_ATTRIBUTE);
-		createEAttribute(propertyAttributeEClass, PROPERTY_ATTRIBUTE__TYPE);
-		createEAttribute(propertyAttributeEClass, PROPERTY_ATTRIBUTE__VALUE);
+
+		booleanPropertyAttributeEClass = createEClass(BOOLEAN_PROPERTY_ATTRIBUTE);
+		createEAttribute(booleanPropertyAttributeEClass, BOOLEAN_PROPERTY_ATTRIBUTE__TYPE);
+		createEAttribute(booleanPropertyAttributeEClass, BOOLEAN_PROPERTY_ATTRIBUTE__VALUE);
+
+		enumLiteralPropertyAttributeEClass = createEClass(ENUM_LITERAL_PROPERTY_ATTRIBUTE);
+		createEAttribute(enumLiteralPropertyAttributeEClass, ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE);
+		createEReference(enumLiteralPropertyAttributeEClass, ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE);
 
 		// Create enums
 		primitiveTypeEEnum = createEEnum(PRIMITIVE_TYPE);
 		constraintIntervalTypeEEnum = createEEnum(CONSTRAINT_INTERVAL_TYPE);
-		propertyAttributeTypeEEnum = createEEnum(PROPERTY_ATTRIBUTE_TYPE);
+		booleanPropertyAttributeTypeEEnum = createEEnum(BOOLEAN_PROPERTY_ATTRIBUTE_TYPE);
+		enumLiteralPropertyAttributeTypeEEnum = createEEnum(ENUM_LITERAL_PROPERTY_ATTRIBUTE_TYPE);
 	}
 
 	/**
@@ -609,6 +686,8 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 		objectPropertyTypeEClass.getESuperTypes().add(this.getPropertyType());
 		enumEClass.getESuperTypes().add(this.getType());
 		typeEClass.getESuperTypes().add(theModelPackage.getModel());
+		booleanPropertyAttributeEClass.getESuperTypes().add(this.getPropertyAttribute());
+		enumLiteralPropertyAttributeEClass.getESuperTypes().add(this.getPropertyAttribute());
 
 		// Initialize classes and features; add operations and parameters
 		initEClass(entityEClass, Entity.class, "Entity", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -648,9 +727,15 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 
 		initEClass(propertyTypeEClass, PropertyType.class, "PropertyType", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(propertyAttributeEClass, PropertyAttribute.class, "PropertyAttribute", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(getPropertyAttribute_Type(), this.getPropertyAttributeType(), "type", null, 0, 1, PropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getPropertyAttribute_Value(), ecorePackage.getEString(), "value", null, 0, 1, PropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(propertyAttributeEClass, PropertyAttribute.class, "PropertyAttribute", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+
+		initEClass(booleanPropertyAttributeEClass, BooleanPropertyAttribute.class, "BooleanPropertyAttribute", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getBooleanPropertyAttribute_Type(), this.getBooleanPropertyAttributeType(), "type", null, 0, 1, BooleanPropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getBooleanPropertyAttribute_Value(), ecorePackage.getEBoolean(), "value", null, 0, 1, BooleanPropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(enumLiteralPropertyAttributeEClass, EnumLiteralPropertyAttribute.class, "EnumLiteralPropertyAttribute", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getEnumLiteralPropertyAttribute_Type(), this.getEnumLiteralPropertyAttributeType(), "type", null, 0, 1, EnumLiteralPropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getEnumLiteralPropertyAttribute_Value(), this.getEnumLiteral(), null, "value", null, 0, 1, EnumLiteralPropertyAttribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize enums and add enum literals
 		initEEnum(primitiveTypeEEnum, PrimitiveType.class, "PrimitiveType");
@@ -673,11 +758,13 @@ public class DatatypePackageImpl extends EPackageImpl implements DatatypePackage
 		addEEnumLiteral(constraintIntervalTypeEEnum, ConstraintIntervalType.MIMETYPE);
 		addEEnumLiteral(constraintIntervalTypeEEnum, ConstraintIntervalType.SCALING);
 
-		initEEnum(propertyAttributeTypeEEnum, PropertyAttributeType.class, "PropertyAttributeType");
-		addEEnumLiteral(propertyAttributeTypeEEnum, PropertyAttributeType.MEASUREMENT_UNIT);
-		addEEnumLiteral(propertyAttributeTypeEEnum, PropertyAttributeType.READABLE);
-		addEEnumLiteral(propertyAttributeTypeEEnum, PropertyAttributeType.WRITABLE);
-		addEEnumLiteral(propertyAttributeTypeEEnum, PropertyAttributeType.EVENTABLE);
+		initEEnum(booleanPropertyAttributeTypeEEnum, BooleanPropertyAttributeType.class, "BooleanPropertyAttributeType");
+		addEEnumLiteral(booleanPropertyAttributeTypeEEnum, BooleanPropertyAttributeType.READABLE);
+		addEEnumLiteral(booleanPropertyAttributeTypeEEnum, BooleanPropertyAttributeType.WRITABLE);
+		addEEnumLiteral(booleanPropertyAttributeTypeEEnum, BooleanPropertyAttributeType.EVENTABLE);
+
+		initEEnum(enumLiteralPropertyAttributeTypeEEnum, EnumLiteralPropertyAttributeType.class, "EnumLiteralPropertyAttributeType");
+		addEEnumLiteral(enumLiteralPropertyAttributeTypeEEnum, EnumLiteralPropertyAttributeType.MEASUREMENT_UNIT);
 
 		// Create resource
 		createResource(eNS_URI);

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/EnumLiteralPropertyAttributeImpl.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/impl/EnumLiteralPropertyAttributeImpl.java
@@ -5,29 +5,31 @@ package org.eclipse.vorto.core.api.model.datatype.impl;
 import org.eclipse.emf.common.notify.Notification;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
-import org.eclipse.vorto.core.api.model.datatype.PropertyAttribute;
-import org.eclipse.vorto.core.api.model.datatype.PropertyAttributeType;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteral;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttributeType;
 
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Property Attribute</b></em>'.
+ * An implementation of the model object '<em><b>Enum Literal Property Attribute</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl#getType <em>Type</em>}</li>
- *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.PropertyAttributeImpl#getValue <em>Value</em>}</li>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.vorto.core.api.model.datatype.impl.EnumLiteralPropertyAttributeImpl#getValue <em>Value</em>}</li>
  * </ul>
  * </p>
  *
  * @generated
  */
-public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implements PropertyAttribute {
+public class EnumLiteralPropertyAttributeImpl extends MinimalEObjectImpl.Container implements EnumLiteralPropertyAttribute {
 	/**
 	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
 	 * <!-- begin-user-doc -->
@@ -36,7 +38,7 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * @generated
 	 * @ordered
 	 */
-	protected static final PropertyAttributeType TYPE_EDEFAULT = PropertyAttributeType.MEASUREMENT_UNIT;
+	protected static final EnumLiteralPropertyAttributeType TYPE_EDEFAULT = EnumLiteralPropertyAttributeType.MEASUREMENT_UNIT;
 
 	/**
 	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
@@ -46,34 +48,24 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * @generated
 	 * @ordered
 	 */
-	protected PropertyAttributeType type = TYPE_EDEFAULT;
+	protected EnumLiteralPropertyAttributeType type = TYPE_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final String VALUE_EDEFAULT = null;
-
-	/**
-	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getValue()
-	 * @generated
-	 * @ordered
-	 */
-	protected String value = VALUE_EDEFAULT;
+	protected EnumLiteral value;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected PropertyAttributeImpl() {
+	protected EnumLiteralPropertyAttributeImpl() {
 		super();
 	}
 
@@ -84,7 +76,7 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return DatatypePackage.Literals.PROPERTY_ATTRIBUTE;
+		return DatatypePackage.Literals.ENUM_LITERAL_PROPERTY_ATTRIBUTE;
 	}
 
 	/**
@@ -92,7 +84,7 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public PropertyAttributeType getType() {
+	public EnumLiteralPropertyAttributeType getType() {
 		return type;
 	}
 
@@ -101,11 +93,11 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setType(PropertyAttributeType newType) {
-		PropertyAttributeType oldType = type;
+	public void setType(EnumLiteralPropertyAttributeType newType) {
+		EnumLiteralPropertyAttributeType oldType = type;
 		type = newType == null ? TYPE_EDEFAULT : newType;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.PROPERTY_ATTRIBUTE__TYPE, oldType, type));
+			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE, oldType, type));
 	}
 
 	/**
@@ -113,7 +105,15 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public String getValue() {
+	public EnumLiteral getValue() {
+		if (value != null && value.eIsProxy()) {
+			InternalEObject oldValue = (InternalEObject)value;
+			value = (EnumLiteral)eResolveProxy(oldValue);
+			if (value != oldValue) {
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE, oldValue, value));
+			}
+		}
 		return value;
 	}
 
@@ -122,11 +122,20 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setValue(String newValue) {
-		String oldValue = value;
+	public EnumLiteral basicGetValue() {
+		return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setValue(EnumLiteral newValue) {
+		EnumLiteral oldValue = value;
 		value = newValue;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.PROPERTY_ATTRIBUTE__VALUE, oldValue, value));
+			eNotify(new ENotificationImpl(this, Notification.SET, DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE, oldValue, value));
 	}
 
 	/**
@@ -137,10 +146,11 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case DatatypePackage.PROPERTY_ATTRIBUTE__TYPE:
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE:
 				return getType();
-			case DatatypePackage.PROPERTY_ATTRIBUTE__VALUE:
-				return getValue();
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE:
+				if (resolve) return getValue();
+				return basicGetValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -153,11 +163,11 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case DatatypePackage.PROPERTY_ATTRIBUTE__TYPE:
-				setType((PropertyAttributeType)newValue);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE:
+				setType((EnumLiteralPropertyAttributeType)newValue);
 				return;
-			case DatatypePackage.PROPERTY_ATTRIBUTE__VALUE:
-				setValue((String)newValue);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE:
+				setValue((EnumLiteral)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -171,11 +181,11 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case DatatypePackage.PROPERTY_ATTRIBUTE__TYPE:
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE:
 				setType(TYPE_EDEFAULT);
 				return;
-			case DatatypePackage.PROPERTY_ATTRIBUTE__VALUE:
-				setValue(VALUE_EDEFAULT);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE:
+				setValue((EnumLiteral)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -189,10 +199,10 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case DatatypePackage.PROPERTY_ATTRIBUTE__TYPE:
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__TYPE:
 				return type != TYPE_EDEFAULT;
-			case DatatypePackage.PROPERTY_ATTRIBUTE__VALUE:
-				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE__VALUE:
+				return value != null;
 		}
 		return super.eIsSet(featureID);
 	}
@@ -209,10 +219,8 @@ public class PropertyAttributeImpl extends MinimalEObjectImpl.Container implemen
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (type: ");
 		result.append(type);
-		result.append(", value: ");
-		result.append(value);
 		result.append(')');
 		return result.toString();
 	}
 
-} //PropertyAttributeImpl
+} //EnumLiteralPropertyAttributeImpl

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/util/DatatypeAdapterFactory.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/util/DatatypeAdapterFactory.java
@@ -9,10 +9,12 @@ import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
 
 import org.eclipse.emf.ecore.EObject;
 
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute;
 import org.eclipse.vorto.core.api.model.datatype.Constraint;
 import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
 import org.eclipse.vorto.core.api.model.datatype.Entity;
 import org.eclipse.vorto.core.api.model.datatype.EnumLiteral;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute;
 import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType;
 import org.eclipse.vorto.core.api.model.datatype.Presence;
 import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType;
@@ -122,6 +124,14 @@ public class DatatypeAdapterFactory extends AdapterFactoryImpl {
 			@Override
 			public Adapter casePropertyAttribute(PropertyAttribute object) {
 				return createPropertyAttributeAdapter();
+			}
+			@Override
+			public Adapter caseBooleanPropertyAttribute(BooleanPropertyAttribute object) {
+				return createBooleanPropertyAttributeAdapter();
+			}
+			@Override
+			public Adapter caseEnumLiteralPropertyAttribute(EnumLiteralPropertyAttribute object) {
+				return createEnumLiteralPropertyAttributeAdapter();
 			}
 			@Override
 			public Adapter caseModel(Model object) {
@@ -298,6 +308,34 @@ public class DatatypeAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createPropertyAttributeAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute <em>Boolean Property Attribute</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute
+	 * @generated
+	 */
+	public Adapter createBooleanPropertyAttributeAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute <em>Enum Literal Property Attribute</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute
+	 * @generated
+	 */
+	public Adapter createEnumLiteralPropertyAttributeAdapter() {
 		return null;
 	}
 

--- a/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/util/DatatypeSwitch.java
+++ b/bundles/org.eclipse.vorto.core/src/org/eclipse/vorto/core/api/model/datatype/util/DatatypeSwitch.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.ecore.EPackage;
 
 import org.eclipse.emf.ecore.util.Switch;
 
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute;
 import org.eclipse.vorto.core.api.model.datatype.Constraint;
 import org.eclipse.vorto.core.api.model.datatype.DatatypePackage;
 import org.eclipse.vorto.core.api.model.datatype.Entity;
 import org.eclipse.vorto.core.api.model.datatype.EnumLiteral;
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute;
 import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType;
 import org.eclipse.vorto.core.api.model.datatype.Presence;
 import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType;
@@ -148,6 +150,20 @@ public class DatatypeSwitch<T> extends Switch<T> {
 			case DatatypePackage.PROPERTY_ATTRIBUTE: {
 				PropertyAttribute propertyAttribute = (PropertyAttribute)theEObject;
 				T result = casePropertyAttribute(propertyAttribute);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case DatatypePackage.BOOLEAN_PROPERTY_ATTRIBUTE: {
+				BooleanPropertyAttribute booleanPropertyAttribute = (BooleanPropertyAttribute)theEObject;
+				T result = caseBooleanPropertyAttribute(booleanPropertyAttribute);
+				if (result == null) result = casePropertyAttribute(booleanPropertyAttribute);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case DatatypePackage.ENUM_LITERAL_PROPERTY_ATTRIBUTE: {
+				EnumLiteralPropertyAttribute enumLiteralPropertyAttribute = (EnumLiteralPropertyAttribute)theEObject;
+				T result = caseEnumLiteralPropertyAttribute(enumLiteralPropertyAttribute);
+				if (result == null) result = casePropertyAttribute(enumLiteralPropertyAttribute);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -317,6 +333,36 @@ public class DatatypeSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T casePropertyAttribute(PropertyAttribute object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Boolean Property Attribute</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Boolean Property Attribute</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseBooleanPropertyAttribute(BooleanPropertyAttribute object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Enum Literal Property Attribute</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Enum Literal Property Attribute</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseEnumLiteralPropertyAttribute(EnumLiteralPropertyAttribute object) {
 		return null;
 	}
 

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
@@ -64,20 +64,35 @@ EnumLiteral:
 
 Property:
 	(presence = Presence)? (multiplicity ?= 'multiple')? name = ID 'as' type = PropertyType
-	('with {' propertyAttributes+=PropertyAttribute (',' propertyAttributes+=PropertyAttribute)* '}')?
+	('with' '{' propertyAttributes+=PropertyAttribute (',' propertyAttributes+=PropertyAttribute)* '}')?
 	('<' Constraints += Constraint ("," Constraints += Constraint)*  '>')?
 	(description=STRING)?
 ;
 
-PropertyAttribute:
-	type=PropertyAttributeType ':' value=STRING
+EnumLiteralName:
+  ID '.' ID
 ;
 
-enum PropertyAttributeType:
-	MeasurementUnit = 'MeasurementUnit' |
-	Readable = 'Readable' |
-	Writable = 'Writable' |
-	Eventable = 'Eventable'
+PropertyAttribute:
+  BooleanPropertyAttribute | EnumLiteralPropertyAttribute
+;
+
+BooleanPropertyAttribute:
+  type=BooleanPropertyAttributeType ':' (value ?= 'true' | 'false')
+;
+
+enum BooleanPropertyAttributeType:
+  readable = 'readable' |
+  writable = 'writable' |
+  eventable = 'eventable'
+;
+
+EnumLiteralPropertyAttribute:
+  type=EnumLiteralPropertyAttributeType ':' value = [EnumLiteral | EnumLiteralName]
+;
+
+enum EnumLiteralPropertyAttributeType:
+  measurementUnit = 'measurementUnit'
 ;
 
 PropertyType:

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/DatatypeRuntimeModule.java
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/DatatypeRuntimeModule.java
@@ -17,7 +17,9 @@
  */
 package org.eclipse.vorto.editor.datatype;
 
+import org.eclipse.vorto.editor.datatype.converter.DatatypeValueConverter;
 import org.eclipse.vorto.editor.datatype.scoping.DatatypeScopeProvider;
+import org.eclipse.xtext.conversion.IValueConverterService;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.scoping.IScopeProvider;
 
@@ -36,5 +38,10 @@ public class DatatypeRuntimeModule extends
 	@Override
 	public Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {
 		return QualifiedNameWithVersionProvider.class;
+	}
+	
+	@Override
+	public Class<? extends IValueConverterService> bindIValueConverterService() {
+		return DatatypeValueConverter.class;
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/converter/DatatypeValueConverter.java
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/converter/DatatypeValueConverter.java
@@ -1,0 +1,61 @@
+package org.eclipse.vorto.editor.datatype.converter;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.xtext.common.services.DefaultTerminalConverters;
+import org.eclipse.xtext.conversion.IValueConverter;
+import org.eclipse.xtext.conversion.ValueConverter;
+import org.eclipse.xtext.conversion.ValueConverterException;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.util.Strings;
+
+public class DatatypeValueConverter extends DefaultTerminalConverters {
+	@ValueConverter(rule = "EnumLiteralName")
+	public IValueConverter<String> EnumLiteralName() {
+		return new IValueConverter<String>() {
+			public String toValue(String string, INode node) throws ValueConverterException {
+				String[] namespaces = string.split("\\.");
+				if (namespaces.length == 2) {
+					Map<String, String> importedModules = getImportedModules(node.getRootNode());
+					String fullName = importedModules.get(namespaces[0]) + "." + string;
+					return fullName;
+				} else {
+					return string;
+				}
+			}
+
+			public String toString(String value) throws ValueConverterException {
+				String[] namespaces = value.split("\\.");
+				if (namespaces.length > 1) {
+					return namespaces[namespaces.length - 2] + "." + namespaces[namespaces.length - 1];
+				}
+				return value;
+			}
+			
+			public Map<String, String> getImportedModules(ICompositeNode rootNode) {
+				Map<String, String> importedModules = new HashMap<String, String>();
+				
+				rootNode.getAsTreeIterable().forEach(new Consumer<INode>() {
+					public void accept(INode t) {
+						String textWithoutWhitespace = Strings.removeLeadingWhitespace(t.getText());
+						if (textWithoutWhitespace != null && textWithoutWhitespace.startsWith("using")) {
+							String[] components = textWithoutWhitespace.split("\\s+");
+							if (components.length > 1) {
+								String[] namespace = components[1].split("\\.");
+								importedModules.put(namespace[namespace.length-1], String.join(".", Arrays.copyOfRange(namespace, 0, namespace.length-1)));
+							}
+						}
+					}
+				});
+				
+				return importedModules;
+			}
+        };
+	}
+	
+	
+}

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
@@ -78,8 +78,8 @@ class DatatypeFormatter extends AbstractDeclarativeFormatter {
 		]
 				
 		//Constraint Parameters
-		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_2_0)
-		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_2_0)	
+		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_3_0)
+		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)	
 		
 		c.setNoSpace().before(f.enumAccess.commaKeyword_11_1_0)
 	}

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
@@ -77,8 +77,8 @@ class FunctionblockFormatter extends AbstractDeclarativeFormatter {
 		c.setLinewrap(1).after(f.operationAccess.group)
 	
 		//Constraint parameters.
-		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_2_0)
-		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_2_0)
+		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_3_0)
+		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)
 		
 		//Operation parameters.
 		c.setNoSpace().before(f.operationAccess.commaKeyword_2_1_0)


### PR DESCRIPTION
Set measurementUnit to an enumeration literal type so you can do something like this:

```
using com.mycompany.type.Temperature ; 1.0.0
...
mandatory heat as int with { measurementUnit : Temperature.C }

```

Set readable, writable, and eventable to Boolean type.

`mandatory heat as int with { eventable: true, writable : false, readable : false }`

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>