### PR TITLE
Fix for https://github.com/eclipse/vorto/issues/63 - Mapping-rules of events ignored

### DIFF
--- a/bundles/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/ConfigurationElementLookup.java
+++ b/bundles/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/ConfigurationElementLookup.java
@@ -18,9 +18,11 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Bundle;
 
 public class ConfigurationElementLookup {
 
+	private static final String BUNDLE_NAME = "Bundle-Name";
 	private IExtensionRegistry EXTENSION_REGISTRY = Platform
 			.getExtensionRegistry();
 	private static ConfigurationElementLookup instance;
@@ -45,6 +47,19 @@ public class ConfigurationElementLookup {
 		IExtension extension = EXTENSION_REGISTRY.getExtension(extensionPtId,
 				id);
 		return extension.getConfigurationElements();
+	}
+	
+	public String getExtensionSimpleIdentifier(String extensionPtId, String id) {
+		IExtension extension = EXTENSION_REGISTRY.getExtension(extensionPtId,
+				id);
+		if (extension != null && extension.getContributor() != null) {
+			
+			Bundle bundle = Platform.getBundle(extension.getContributor().getName());
+
+			return bundle.getHeaders().get(BUNDLE_NAME);
+		}
+		
+		return null;
 	}
 
 	public void setExtensionRegistry(IExtensionRegistry reg) {

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/AbstractModelProject.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/AbstractModelProject.java
@@ -17,6 +17,7 @@ package org.eclipse.vorto.core.model;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.vorto.core.api.model.datatype.Type;
 import org.eclipse.vorto.core.api.model.functionblock.FunctionblockModel;
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel;
+import org.eclipse.vorto.core.api.model.mapping.MappingModel;
 import org.eclipse.vorto.core.api.model.model.Model;
 import org.eclipse.vorto.core.api.model.model.ModelId;
 import org.eclipse.vorto.core.api.model.model.ModelReference;
@@ -138,8 +140,8 @@ public abstract class AbstractModelProject extends AbstractModelElement implemen
 	}
 
 	@Override
-	public IMapping getMapping(String targetPlatform){
-		return MappingResourceFactory.getInstance().createMapping(this, targetPlatform);		
+	public Collection<MappingModel> getMapping(String targetPlatform){
+		return MappingResourceFactory.getInstance().getMappingModels(this, targetPlatform);		
 	}
 	
 	protected IModelElementResolver[] getResolvers() {

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/IModelProject.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/IModelProject.java
@@ -14,9 +14,12 @@
  *******************************************************************************/
 package org.eclipse.vorto.core.model;
 
+import java.util.Collection;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.vorto.core.api.model.mapping.MappingModel;
 import org.eclipse.vorto.core.api.model.model.ModelId;
 
 /**
@@ -60,7 +63,7 @@ public interface IModelProject extends IModelElement {
 	 * @param targetPlatform: Target platform name the mapping designed for
 	 * @return instance if IMapping
 	 */
-	IMapping getMapping(String targetPlatform);
+	Collection<MappingModel> getMapping(String targetPlatform);
 
 	/**
 	 * Saves the actual model project, after it has been modified, e.g. after

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/MappingResourceFactory.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/MappingResourceFactory.java
@@ -81,6 +81,19 @@ public class MappingResourceFactory {
 		List<IMapping> referenceMappings = this.getReferenceMappings(ownerModelElement, targetPlatform);
 		return createMapping(mappingModel, referenceMappings);
 	}
+	
+	/**
+	 * Returns all the mapping models of a particular project
+	 * @param ownerModelElement
+	 * @param targetPlatform
+	 * @return
+	 */
+	public List<MappingModel> getMappingModels(IModelElement ownerModelElement, String targetPlatform) {
+		List<MappingModel> mappingModels = new ArrayList<MappingModel>();
+		mappingModels.add(getMappingModel(ownerModelElement, targetPlatform));
+		mappingModels.addAll(getReferenceMappingModels(ownerModelElement, targetPlatform));
+		return mappingModels;
+	}
 
 	/**
 	 * Create IMapping instance based on given Mapping Model and child IMapping 
@@ -146,6 +159,14 @@ public class MappingResourceFactory {
 		}
 		
 		return mappingModel;
+	}
+	
+	private List<MappingModel> getReferenceMappingModels(IModelElement ownerModelElement, String targetPlatform) {
+		List<MappingModel> referenceMappings = new ArrayList<MappingModel>();
+		for (IModelElement referenceModelElement : ownerModelElement.getReferences()) {
+			referenceMappings.add(getMappingModel(referenceModelElement, targetPlatform));
+		}
+		return referenceMappings;
 	}
 
 	private List<IMapping> getReferenceMappings(IModelElement ownerModelElement, String targetPlatform) {


### PR DESCRIPTION
Fix for https://github.com/eclipse/vorto/issues/63 - 
Mapping-rules of events are ignored when generating code.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>