### PR TITLE
Error during invocation of code generators

### DIFF
--- a/server/generators/org.eclipse.vorto.codegen.service/src/main/java/org/eclipse/vorto/service/generator/web/utils/ModelZipFileExtractor.java
+++ b/server/generators/org.eclipse.vorto.codegen.service/src/main/java/org/eclipse/vorto/service/generator/web/utils/ModelZipFileExtractor.java
@@ -31,6 +31,7 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 
 import com.google.inject.Injector;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Alexander Edelmann - Robert Bosch (SEA) Pte. Ltd.
@@ -56,7 +57,7 @@ public class ModelZipFileExtractor extends AbstractZipFileExtractor {
 		Resource infoModelResource = null;
 		try {
 			while ((entry = zis.getNextEntry()) != null) {
-				if (entry.getName().contains(modelId.getName())) {
+				if (StringUtils.stripFilenameExtension(entry.getName()).equals(modelId.getName())) {
 					infoModelResource = resourceSet.createResource(URI.createURI("fake:/" + entry.getName()));
 					infoModelResource.load(new ByteArrayInputStream(copyStream(zis, entry)),
 							resourceSet.getLoadOptions());


### PR DESCRIPTION
Errors when infomodel and function block model share similar names. Checking for exact model names instead of partial check. closes #115

Signed-off-by: Nagavijay Sivakumar <nagavijay.sivakumar@bosch-si.com>