### PR TITLE
Improve validation error reporting

### DIFF
--- a/server/repo/repo-core/src/main/java/org/eclipse/vorto/repository/model/UploadModelResult.java
+++ b/server/repo/repo-core/src/main/java/org/eclipse/vorto/repository/model/UploadModelResult.java
@@ -15,6 +15,9 @@
 package org.eclipse.vorto.repository.model;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.vorto.repository.internal.service.validation.exception.CouldNotResolveReferenceException;
 import org.eclipse.vorto.repository.validation.ValidationException;
@@ -43,6 +46,31 @@ public class UploadModelResult {
 		this.unresolvedReferences = missingReferences;
 	}
 
+	public static UploadModelResult invalid(ValidationException... validationExceptions) {
+		Objects.requireNonNull(validationExceptions);
+		if (validationExceptions.length <= 0) {
+			throw new IllegalArgumentException("There ought to be more than 1 validation exception for this function.");
+		}
+		
+		StringBuffer errorMessage = new StringBuffer();
+		List<ModelId> missingReferences = Collections.emptyList();
+		for(int i=0; i < validationExceptions.length; i++) {
+			if (validationExceptions[i] instanceof CouldNotResolveReferenceException) {
+				missingReferences = ((CouldNotResolveReferenceException) validationExceptions[i]).getMissingReferences();
+			}
+			
+			if (errorMessage.length() != 0) {
+				errorMessage.append("\n");
+			}
+			errorMessage.append((i + 1));
+			errorMessage.append(") ");
+			errorMessage.append(validationExceptions[i].getMessage());
+		}
+		
+		return new UploadModelResult(null, validationExceptions[0].getModelResource(), false,
+				errorMessage.toString(), missingReferences);
+	}
+	
 	public static UploadModelResult invalid(CouldNotResolveReferenceException validationException) {
 		return new UploadModelResult(null, validationException.getModelResource(), false,
 				validationException.getMessage(), validationException.getMissingReferences());


### PR DESCRIPTION
Collate all validation errors such that we can show all possible validation errors to the user.

So, if an uploaded model contains both a "model already exist" and "missing model references", both are shown in the UI.

Signed-off-by: erlemantos <erleczar.mantos@bosch-si.com>