### PR TITLE
Enums are now not required to have literals. Closes #185

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeValidator.xtend
@@ -68,9 +68,6 @@ public val propertyValidator = new PropertyConstraintMappingValidation
 		if (isCamelCasedName(name)) {
 			error(DatatypeSystemMessage.ERROR_ENUMNAME_INVALID_CAMELCASE, ent, ModelPackage.Literals.MODEL__NAME)
 		}
-		if(ent.getEnums().empty){
-			error(DatatypeSystemMessage.ERROR_ENUM_CANNOT_BE_EMPTY, ent, DatatypePackage.Literals.ENUM__ENUMS)
-		}
 	}
 	
 	@Check


### PR DESCRIPTION
There are no requirements for Enums to contain literals. This is so that we don't get an invalid enum when creating a new one.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>