### PR TITLE
Fix for #183 and #184

### DIFF
--- a/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListener.java
+++ b/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListener.java
@@ -71,9 +71,7 @@ public class ModelDropListener extends ViewerDropAdapter {
 
 			if (result != null) {
 				ModelProjectTreeViewer viewer = (ModelProjectTreeViewer) this.getViewer();
-
 				viewer.getLocalModelWorkspace().refreshCurrent();
-
 				IModelElement targetModelElement = findTarget((IModelElement) target,
 						(Collection<IModelElement>) viewer.getInput());
 				if (targetModelElement != null) {

--- a/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListener.java
+++ b/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListener.java
@@ -87,9 +87,12 @@ public class ModelDropListener extends ViewerDropAdapter {
 	}
 
 	private IModelElement findTarget(IModelElement target, Collection<IModelElement> inputModelElements) {
-		return inputModelElements.stream().filter((IModelElement e) -> {
-			return e.getId().equals(target.getId());
-		}).findFirst().orElse(null);
+		for(IModelElement e : inputModelElements) {
+			if (e.getId().equals(target.getId())) {
+				return e;
+			}
+		}
+		return null;
 	}
 
 	private Object getTarget() {

--- a/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListenerFactory.java
+++ b/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/dnd/ModelDropListenerFactory.java
@@ -26,7 +26,6 @@ import org.eclipse.vorto.perspective.dnd.dropaction.AddLocalReferenceDropAction;
 import org.eclipse.vorto.perspective.dnd.dropaction.AddSharedReferenceDropAction;
 import org.eclipse.vorto.perspective.dnd.dropaction.RepositoryResourceDropAction;
 import org.eclipse.vorto.perspective.dnd.dropvalidator.DatatypeValidator;
-import org.eclipse.vorto.perspective.dnd.dropvalidator.ModelTypeValidator;
 import org.eclipse.vorto.perspective.dnd.dropvalidator.TargetClassModelTypeValidator;
 import org.eclipse.vorto.perspective.dnd.dropvalidator.TargetClassSourceClassValidator;
 

--- a/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ILocalModelWorkspace.java
+++ b/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ILocalModelWorkspace.java
@@ -29,6 +29,11 @@ public interface ILocalModelWorkspace {
 	 * refreshes the model browser by reloading all models for the selected project
 	 */
 	void refresh();
+	
+	/**
+	 * Only refreshes the current selected project
+	 */
+	void refreshCurrent();
 			
 	public interface IModelProjectBrowser {
 				

--- a/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ProjectSelectionViewPart.java
+++ b/bundles/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ProjectSelectionViewPart.java
@@ -111,12 +111,12 @@ public class ProjectSelectionViewPart extends ViewPart implements ILocalModelWor
 		});
 
 		projectSelectionViewer.setContentProvider(ArrayContentProvider.getInstance());
-		projectSelectionViewer.setInput(getModelProjects());
+		Collection<IModelProject> modelProjects = getModelProjects(); 
+		projectSelectionViewer.setInput(modelProjects);
 
 		projectSelectionViewer.addSelectionChangedListener(new ISelectionChangedListener() {
 			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
-
 				if (event.getSelection() instanceof IStructuredSelection) {
 					IStructuredSelection iSelection = (IStructuredSelection) event.getSelection();
 					IModelProject project = (IModelProject) iSelection.getFirstElement();
@@ -136,9 +136,9 @@ public class ProjectSelectionViewPart extends ViewPart implements ILocalModelWor
 		infoModelTreeViewer = new InfomodelTreeViewer(modelPanel, this);
 
 		getSite().setSelectionProvider(infoModelTreeViewer.treeViewer);
-
-		if (!getModelProjects().isEmpty()) {
-			setSelectedProject(getModelProjects().iterator().next());
+		
+		if (!modelProjects.isEmpty()) {
+			setSelectedProject(modelProjects.iterator().next());
 		}
 
 	}
@@ -167,6 +167,12 @@ public class ProjectSelectionViewPart extends ViewPart implements ILocalModelWor
 		for (IModelProject project : getModelProjects()) {
 			populate(project);
 		}
+	}
+	
+	public void refreshCurrent() {
+		// setting the selected project will call populate on that project which in turn
+		// will refresh it
+		setSelectedProject(selectedProject);
 	}
 
 	private ComboViewer createProjectSelectionViewer(final Composite container, String labelStr) {


### PR DESCRIPTION
Fixes the following:
- #183 With more than one project in the perspective, project selector jumps to first project after Drag & Drop was used
- #184 Expand model element (level:2) after a model was dropped onto it