### PR TITLE
Fixes #616 - Model explorer missing in the Vorto perspective

### DIFF
--- a/bundles/org.eclipse.vorto.perspective.vorto/plugin.xml
+++ b/bundles/org.eclipse.vorto.perspective.vorto/plugin.xml
@@ -46,7 +46,7 @@
               category="org.eclipse.vorto.perspective"
               class="org.eclipse.vorto.perspective.vorto.view.VortoProjectSelectionViewPart"
               icon="platform:/plugin/org.eclipse.vorto.perspective/icons/vorto-icon.png"
-              id="org.eclipse.vorto.perspective.view.ProjectSelectionViewPart"
+              id="org.eclipse.vorto.perspective.view.VortoProjectSelectionViewPart"
               name="Vorto Model Project Browser">
         </view>
         <view

--- a/bundles/org.eclipse.vorto.perspective.vorto/src/org/eclipse/vorto/perspective/VortoPerspective.java
+++ b/bundles/org.eclipse.vorto.perspective.vorto/src/org/eclipse/vorto/perspective/VortoPerspective.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.vorto.perspective;
 
+import org.eclipse.ui.IFolderLayout;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveFactory;
 import org.eclipse.vorto.perspective.vorto.view.VortoProjectSelectionViewPart;
@@ -23,16 +24,8 @@ public class VortoPerspective implements IPerspectiveFactory {
 	@Override
 	public void createInitialLayout(IPageLayout layout) {
 				
-		layout.createFolder("left", IPageLayout.LEFT, 0.2f,
-				IPageLayout.ID_EDITOR_AREA);
-		layout.createFolder("right", IPageLayout.RIGHT, 0.6f,
-				IPageLayout.ID_EDITOR_AREA);
-		layout.createFolder("bottom", IPageLayout.BOTTOM, 0.8f,
-				IPageLayout.ID_EDITOR_AREA);
-		layout.createFolder("top", IPageLayout.TOP, 0.6f,
-				IPageLayout.ID_EDITOR_AREA);
+		IFolderLayout left = layout.createFolder("left", IPageLayout.LEFT, 0.2f, layout.getEditorArea());
 
-		layout.addView(VortoProjectSelectionViewPart.PROJECT_SELECT_VIEW_ID, IPageLayout.LEFT, 0.20f,
-				layout.getEditorArea());
+		left.addView(VortoProjectSelectionViewPart.PROJECT_SELECT_VIEW_ID);
 	}
 }

--- a/bundles/org.eclipse.vorto.perspective.vorto/src/org/eclipse/vorto/perspective/vorto/view/VortoProjectSelectionViewPart.java
+++ b/bundles/org.eclipse.vorto.perspective.vorto/src/org/eclipse/vorto/perspective/vorto/view/VortoProjectSelectionViewPart.java
@@ -22,7 +22,7 @@ import org.eclipse.vorto.wizard.vorto.VortoProjectWizard;
 
 public class VortoProjectSelectionViewPart extends AbstractProjectSelectionViewPart {
 
-	public static final String PROJECT_SELECT_VIEW_ID = "org.eclipse.vorto.perspective.vorto.view.VortoProjectSelectionViewPart";
+	public static final String PROJECT_SELECT_VIEW_ID = "org.eclipse.vorto.perspective.view.VortoProjectSelectionViewPart";
 
 	@Override
 	protected ModelTreeViewer getDataTypeTreeViewer(Composite modelPanel) {


### PR DESCRIPTION
Model explorer missing in the Vorto perspective of 0.10.M1 Snapshot version

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>