### PR TITLE
Fixes #622

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeSystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeSystemMessage.xtend
@@ -20,6 +20,8 @@ class DatatypeSystemMessage {
 	public static final String ERROR_OBJ_PROPERTY_CIRCULAR_REF = 'Object property type has circular reference'
 	public static final String ERROR_SUPERTYPE_CIRCULAR_REF = 'Super type has circular reference'
 	
+	public static final String ERROR_PROPERTY_TYPE_NOT_IMPORTED = "This property type has not been imported"
+	
 	public static final String ERROR_DUPLICATED_ENTITY_NAME = 'Entity name has been defined'
 	public static final String ERROR_DUPLICATED_PROPERTY_NAME = 'Property name has been defined'
 

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/DatatypeValidator.xtend
@@ -171,4 +171,14 @@ class DatatypeValidator extends AbstractDatatypeValidator {
 			error(DatatypeSystemMessage.ERROR_PROPNAME_SUFFIX_TS, property, DatatypePackage.Literals.PROPERTY__NAME)
 		}
 	}
+	
+	@Check
+	def checkPropertyIfInReferences(Property property) {
+		if (property.type instanceof ObjectPropertyType) {
+			var topParent = ValidatorUtils.getParentOfType(property, Model) as Model
+			if (topParent != null && !ValidatorUtils.isTypeInReferences((property.type as ObjectPropertyType).type, topParent.references)) {
+				error(DatatypeSystemMessage.ERROR_PROPERTY_TYPE_NOT_IMPORTED, property, DatatypePackage.Literals.PROPERTY__TYPE)
+			}	
+		}
+	}
 }

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/ValidatorUtils.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/ValidatorUtils.xtend
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists
 import java.util.Collection
 import java.util.HashMap
 import java.util.Map
+import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.vorto.core.api.model.datatype.DictionaryPropertyType
 import org.eclipse.vorto.core.api.model.datatype.Entity
@@ -15,6 +16,7 @@ import org.eclipse.vorto.core.api.model.datatype.PropertyType
 import org.eclipse.vorto.core.api.model.functionblock.FunctionblockModel
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel
 import org.eclipse.vorto.core.api.model.model.Model
+import org.eclipse.vorto.core.api.model.model.ModelReference
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils.ModelTypeBasedChildrenSupplier
 
 public class ValidatorUtils {
@@ -29,6 +31,17 @@ public class ValidatorUtils {
 		} else {
 			return getParentOfType(obj.eContainer, type);	
 		}
+	}
+	
+	public static def boolean isTypeInReferences(Model type, EList<ModelReference> references) {
+		val propertySig = type.namespace + "." + type.name + ":" +  type.version
+		for(ref : references) {
+			val refSig = ref.importedNamespace + ":" + ref.version
+			if (propertySig.equals(refSig)) {
+				return true;
+			}
+		}
+		return false
 	}
 	
 	public static def boolean hasCircularReference(Model parent, Model child, ModelTypeBasedChildrenSupplier modelTypeChildrenSupplier) {

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -32,6 +32,8 @@ import org.eclipse.vorto.core.api.model.functionblock.FunctionblockModel
 import org.eclipse.vorto.core.api.model.functionblock.FunctionblockPackage
 import org.eclipse.vorto.core.api.model.functionblock.Operation
 import org.eclipse.vorto.core.api.model.functionblock.PrimitiveParam
+import org.eclipse.vorto.core.api.model.functionblock.RefParam
+import org.eclipse.vorto.core.api.model.functionblock.ReturnObjectType
 import org.eclipse.vorto.core.api.model.functionblock.ReturnPrimitiveType
 import org.eclipse.vorto.core.api.model.functionblock.Status
 import org.eclipse.vorto.core.api.model.model.ModelPackage
@@ -233,6 +235,22 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 			} catch(Exception e) {
 				e.printStackTrace
 			}
+		}
+	}
+	
+	@Check
+	def checkRefParamIsImported(RefParam refParam) {
+		val topParent = ValidatorUtils.getParentOfType(refParam, FunctionblockModel) as FunctionblockModel
+		if (topParent != null && !ValidatorUtils.isTypeInReferences(refParam.type, topParent.references)) {
+			error(SystemMessage.ERROR_REF_PARAM_NOT_IMPORTED, refParam, FunctionblockPackage.Literals.REF_PARAM__TYPE);
+		}
+	}
+	
+	@Check
+	def checkRefParamIsImported(ReturnObjectType returnType) {
+		val topParent = ValidatorUtils.getParentOfType(returnType, FunctionblockModel) as FunctionblockModel
+		if (topParent != null && !ValidatorUtils.isTypeInReferences(returnType.returnType, topParent.references)) {
+			error(SystemMessage.ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED, returnType, FunctionblockPackage.Literals.RETURN_OBJECT_TYPE__RETURN_TYPE);
 		}
 	}
 	

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
@@ -32,4 +32,8 @@ class SystemMessage {
 
 	public static final String ERROR_NAMESPACE_PATTERN = 'Namespace should have following pattern: <[a-z0-9]+(.[a-z0-9])*> E.g com.bosch, com.bosch.lightsystem'
 	
+	public static final String ERROR_REF_PARAM_NOT_IMPORTED = "Reference parameter has not yet been imported.";
+	
+	public static final String ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED = "Return type has not yet been imported.";
+	
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.vorto.editor.infomodel/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtend.lib,
  org.eclipse.vorto.editor.functionblock
 Import-Package: org.apache.log4j,
- org.eclipse.vorto.editor.datatype.converter
+ org.eclipse.vorto.editor.datatype.converter,
+ org.eclipse.vorto.editor.datatype.validation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.vorto.editor.infomodel,org.eclipse.vorto.e
  ditor.infomodel.formatting,org.eclipse.vorto.editor.infomodel.generat

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
@@ -16,8 +16,10 @@
 package org.eclipse.vorto.editor.infomodel.validation
 
 import java.util.HashSet
+import org.eclipse.vorto.core.api.model.informationmodel.FunctionblockProperty
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModelPackage
+import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
 
 /**
@@ -36,5 +38,12 @@ class InformationModelValidator extends AbstractInformationModelValidator {
 			}
 		}
 	}
-
+	
+	@Check
+	def checkFunctionBlockIsImported(FunctionblockProperty property) {
+		val topParent = ValidatorUtils.getParentOfType(property, InformationModel) as InformationModel
+		if (topParent != null && !ValidatorUtils.isTypeInReferences(property.type, topParent.references)) {
+			error(SystemMessage.ERROR_FUNCTIONBLOCK_NOT_IMPORTED, property, InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__TYPE)
+		}
+	}
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
@@ -19,4 +19,5 @@
 
 class SystemMessage {
 	public static final String ERROR_DUPLICATED_FUNCTIONBLOCK_NAME = 'Function Block is already defined'
+	public static final String ERROR_FUNCTIONBLOCK_NOT_IMPORTED = 'This Function Block has not yet been imported.'
 }


### PR DESCRIPTION
Add validators to check if properties, reference parameters, object return types, and function blocks have an equivalent import statement (using ....)

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>