### PR TITLE
Minor improvement to the generated Kura code. 

### DIFF
--- a/generators/org.eclipse.vorto.codegen.kura/src/org/eclipse/vorto/codegen/kura/templates/bluetooth/DeviceBluetoothFinderTemplate.xtend
+++ b/generators/org.eclipse.vorto.codegen.kura/src/org/eclipse/vorto/codegen/kura/templates/bluetooth/DeviceBluetoothFinderTemplate.xtend
@@ -200,8 +200,10 @@ public class «element.name»BluetoothFinder implements ConfigurableComponent {
 							.filter(new «element.name»DeviceFilter(configuration))
 							// Add any device we haven't found yet
 							.collect(Collectors.toList());
-					synchronized(physicalDevicesLock) {
-						physicalDevices = scannedDevices;
+					if (!scannedDevices.isEmpty()) {
+						synchronized(physicalDevicesLock) {
+							physicalDevices = scannedDevices;
+						}
 					}
 				}
 			});


### PR DESCRIPTION
Don't replace device list if device discovery returns empty, because sometimes, device scan can return 0 devices even if device is present.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>