### PR TITLE
Store smart table search state in location hash

### DIFF
--- a/server/devtool/webeditor/src/main/resources/application-local.yml
+++ b/server/devtool/webeditor/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 vorto:
   repository:
     base:
-      path: http://vorto.eclipse.org
+      path: http://localhost:8080/infomodelrepository
 
 http:
   proxyHost:

--- a/server/repo/repository-server/src/main/resources/static/index.html
+++ b/server/repo/repository-server/src/main/resources/static/index.html
@@ -61,7 +61,7 @@
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-          	<li><a href="./#/">Search</a></li>
+          	<li><a href="./#/" st-reset>Search</a></li>
           	<li ng-show="authenticated && userInfo.isRegistered === 'true'"><a href="./#/upload">Share</a></li>
           	<li ng-show="authority == 'ROLE_ADMIN'"><a href="./#/manage">Manage</a></li>
           	<li><a href="./#/generators">Generators</a></li>

--- a/server/repo/repository-server/src/main/resources/static/partials/details-template.html
+++ b/server/repo/repository-server/src/main/resources/static/partials/details-template.html
@@ -4,7 +4,7 @@
 
 		<div class="row">
 			<div class="project-selection">
-				<a href="./#/"><i class="fa fa-fw fa-long-arrow-left"></i>Go Back</a>  
+				<a href="./#/" st-backlink><i class="fa fa-fw fa-long-arrow-left"></i>Go Back</a>  
 			</div>
 		</div> 
 

--- a/server/repo/repository-server/src/main/resources/static/partials/search-template.html
+++ b/server/repo/repository-server/src/main/resources/static/partials/search-template.html
@@ -30,7 +30,7 @@
 		<div class="row" id="searchResult">
 			
 			<div>
-				<table st-table="displayedModels" st-safe-src="models" class="table table-striped">
+				<table st-persist st-table="displayedModels" st-safe-src="models" class="table table-striped">
 					<thead>
 						<tr>
 							<th colspan="10">


### PR DESCRIPTION
Currently the search in the Vorto repository is always resetting after a site change. The idea is to use the location hash to store the state.

Changed:
- search results are now shareable by url (search string, type, pagination and order are stored)
- SearchController will be reloaded after clicking the search tab again
- DetailsController has a link to the previous result if exists
- reload of search result is possible