### PR TITLE
Fixed pagination in repository search

### DIFF
--- a/server/repo/repository-server/src/main/resources/static/js/app.js
+++ b/server/repo/repository-server/src/main/resources/static/js/app.js
@@ -5,7 +5,8 @@ repository.config([ "$routeProvider", "$httpProvider", function($routeProvider, 
 
     $routeProvider.when("/", {
         templateUrl : "partials/search-template.html",
-        controller : "SearchController"
+        controller : "SearchController",
+        reloadOnSearch: false
     }).when("/upload", {
         templateUrl : "partials/upload-template.html",
         controller : "UploadController"

--- a/server/repo/repository-server/src/main/resources/static/js/directives.js
+++ b/server/repo/repository-server/src/main/resources/static/js/directives.js
@@ -128,8 +128,8 @@ repository.directive('stPersist', ['$location', '$rootScope', function ($locatio
             	}
             	hasState = true;
             }
-            if(searchState.page) {
-            	savedState.pagination.start = searchState.page;
+            if(searchState.start) {
+            	savedState.pagination.start = searchState.parseInt(start);
             	hasState = true;
             }
             angular.extend(tableState, savedState);


### PR DESCRIPTION
The pagination has not worked anymore. The pagination start is now correctly handled in the location hash. There is still an issue that the pagination start is not loaded. Will fix this in later pull request. It is related to this issue: https://github.com/lorenzofox3/Smart-Table/issues/641 

Signed-off-by: Simon Pizonka <simon@pizonka.de>