### PR TITLE
Fix pagination start restore from location hash

### DIFF
--- a/server/repo/repository-server/src/main/resources/static/js/directives.js
+++ b/server/repo/repository-server/src/main/resources/static/js/directives.js
@@ -90,20 +90,25 @@ function generateSearchUrl(tableState) {
 repository.directive('stPersist', ['$location', '$rootScope', function ($location, $rootScope) {
     return {
         require: '^stTable',
-        controller: 'SearchController',
         link: function (scope, element, attr, ctrl) {
             scope.$watch(function () {
                 return ctrl.tableState();
             }, function (newValue, oldValue) {
-                if (newValue !== oldValue) {
+            	if (newValue.pagination.start2) {
+            	    if (newValue.pagination.start2 < newValue.pagination.totalItemCount) {
+            		newValue.pagination.start = newValue.pagination.start2;
+            		newValue.pagination.start2 = undefined;
+            		ctrl.pipe();
+            	    }
+                }
+                if (newValue !== oldValue) {        	
                 	$location.search(generateSearchUrl(newValue));
                 	$rootScope.searchState = newValue;
                 }
             }, true);
-
+            
             // load previous state
             var tableState = ctrl.tableState();
-            console.log(tableState);
             var savedState = {};
             var hasState = false;
             angular.copy(tableState, savedState);
@@ -129,7 +134,7 @@ repository.directive('stPersist', ['$location', '$rootScope', function ($locatio
             	hasState = true;
             }
             if(searchState.start) {
-            	savedState.pagination.start = parseInt(searchState.start);
+            	savedState.pagination.start2 = parseInt(searchState.start);
             	hasState = true;
             }
             angular.extend(tableState, savedState);

--- a/server/repo/repository-server/src/main/resources/static/partials/search-template.html
+++ b/server/repo/repository-server/src/main/resources/static/partials/search-template.html
@@ -66,7 +66,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						<tr ng-repeat="model in displayedModels" ng-click="go(model)">
+						<tr ng-repeat="model in displayedModels track by $index" ng-click="go(model)">
 							<td ng-show="model.type === 'InformationModel'"><img src="images/im.png" /></td>
 							<td ng-show="model.type === 'Functionblock'"><img src="images/fb.png" /></td>
 							<td ng-show="model.type === 'Datatype'"><img src="images/dt.png" /></td>


### PR DESCRIPTION
Using the "hack" from https://github.com/lorenzofox3/Smart-Table/issues/641 the restore of the pagination state is now working.