### PR TITLE
Added presence parameter to operation in functionblock

### DIFF
--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
@@ -72,7 +72,7 @@ Fault:
 ;
  
 Operation :
-	 (breakable ?= 'breakable')? name=ID '(' (params += Param (',' params+=Param)*)?')' ('returns'  returnType = ReturnType)? (description=STRING)?
+	 (presence = Presence)? (breakable ?= 'breakable')? name=ID '(' (params += Param (',' params+=Param)*)?')' ('returns'  returnType = ReturnType)? (description=STRING)?
 ;
 
 ReturnType :

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
@@ -83,8 +83,8 @@ class FunctionblockFormatter extends AbstractDeclarativeFormatter {
 		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)
 		
 		//Operation parameters.
-		c.setNoSpace().before(f.operationAccess.commaKeyword_3_1_0)
-		c.setLinewrap(1).after(f.operationAccess.commaKeyword_3_1_0)
+		c.setNoSpace().before(f.operationAccess.commaKeyword_4_1_0)
+		c.setLinewrap(1).after(f.operationAccess.commaKeyword_4_1_0)
 		
 	}
 }

--- a/framework/org.eclipse.vorto.core/model/Functionblock.ecore
+++ b/framework/org.eclipse.vorto.core/model/Functionblock.ecore
@@ -43,6 +43,8 @@
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="breakable" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="presence" eType="ecore:EClass Datatype.ecore#//Presence"
+        containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ReturnType">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiplicity" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>

--- a/website/documentation/appendix/functionblock-dsl-reference.md
+++ b/website/documentation/appendix/functionblock-dsl-reference.md
@@ -50,7 +50,7 @@ The following code represents the Function Block Model DSL syntax. Function bloc
     ;
 
     operation :
-        ('breakable')? id '(' (param (paramDescription)?)? ')' ('returns'  returnType)? (returnTypeDescription)?
+        ('presence')? ('breakable')? id '(' (param (paramDescription)?)? ')' ('returns'  returnType)? (returnTypeDescription)?
     ;
 
     returnType :


### PR DESCRIPTION
Standards like ZigBee allow a device to not implement all commands for a cluster (not 100% sure about OMA LWM2M). Those commands are mandatory or optional. I propose to add a presence parameter to operations in a functionblock. 

```
functionblock MeteringCluster {
    ...
    operations{
        optional GetProfileResponse()
        optional RequestMirror()
        ...
    }
}
```