### PR TITLE
Workaround for "Could not retrieve Model Project from selection"

### DIFF
--- a/framework/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/CodeGeneratorInvocationHandler.java
+++ b/framework/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/CodeGeneratorInvocationHandler.java
@@ -71,6 +71,9 @@ public class CodeGeneratorInvocationHandler extends AbstractHandler {
 
 		IModelElement selectedElement = ModelProjectFactory.getInstance().getModelElementFromSelection();
 		if (selectedElement == null) {
+			selectedElement = ModelProjectFactory.getInstance().getSelectedModel();
+		}
+		if (selectedElement == null) {
 			MessageDisplayFactory.getMessageDisplay()
 					.displayWarning("Model was not properly selected. Please try again.");
 			return false;

--- a/framework/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/ui/model/ModelProjectFactory.java
+++ b/framework/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/ui/model/ModelProjectFactory.java
@@ -30,6 +30,8 @@ import org.eclipse.ui.PlatformUI;
 public class ModelProjectFactory {
 
 	private static ModelProjectFactory singleton = null;
+	
+	private IModelElement selectedModel;
 
 	private ModelProjectFactory() {
 	}
@@ -92,5 +94,13 @@ public class ModelProjectFactory {
 		} else {
 			throw new IllegalStateException("Could not retrieve Model Project from selection");
 		}
+	}
+
+	public IModelElement getSelectedModel() {
+		return selectedModel;
+	}
+
+	public void setSelectedModel(IModelElement selectedModel) {
+		this.selectedModel = selectedModel;
 	}
 }

--- a/framework/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ModelTreeViewer.java
+++ b/framework/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/view/ModelTreeViewer.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.vorto.core.ui.model.IModelElement;
+import org.eclipse.vorto.core.ui.model.ModelProjectFactory;
 import org.eclipse.vorto.perspective.contentprovider.DefaultTreeModelContentProvider;
 import org.eclipse.vorto.perspective.labelprovider.DefaultTreeModelLabelProvider;
 
@@ -125,6 +126,7 @@ public abstract class ModelTreeViewer {
 						if (selection.getFirstElement() instanceof IModelElement) {
 							IModelElement modelElement = (IModelElement) selection.getFirstElement();
 							if (modelElement.getModelFile() != null) {
+								ModelProjectFactory.getInstance().setSelectedModel(modelElement);
 								openFileInEditor(modelElement.getModelFile());
 							}
 						}


### PR DESCRIPTION
It would be better to bundle command and current selection. But currently this should solve the issue if someone starts the UI and directly tries to generate some code.

Steps to reproduce the issue:
1. Start eclipse with Vorto Plugin
2. Right click on an information model and select some generator.
3. The error message "Could not retrieve Model Project from selection" appears

Signed-off-by: Simon Pizonka <simon@pizonka.de>