### PR TITLE
Save models/filter in root scope to prevent reload on controller change

### DIFF
--- a/server/repo/repository-web/src/main/resources/static/js/controllers.js
+++ b/server/repo/repository-web/src/main/resources/static/js/controllers.js
@@ -1,6 +1,6 @@
 var repositoryControllers = angular.module('repositoryControllers', ['swaggerUi']);
 
-repositoryControllers.controller('SearchController', [ '$scope','$http', '$location', function ($scope,$http,$location) {
+repositoryControllers.controller('SearchController', [ '$scope', '$rootScope', '$http', '$location', function ($scope,$rootScope,$http,$location) {
 
     $scope.models = [];
     $scope.modelType = 'all';
@@ -24,9 +24,15 @@ repositoryControllers.controller('SearchController', [ '$scope','$http', '$locat
         } else {
             filter = $scope.queryFilter + " "+$scope.modelType;
         }
+        if ($rootScope.modelsSaved && $rootScope.modelsSaved.filter === filter) {
+        	// models are already fetched
+        	$scope.models = $rootScope.modelsSaved.models;
+        	return;
+        }
         $http.get('./rest/model/query=' + filter).success(
             function(data, status, headers, config) {
-                $scope.models = data;
+            	$rootScope.modelsSaved = {'filter': filter, 'models': data};
+            	$scope.models = data;
             }).error(function(data, status, headers, config) {
                 $scope.models = [];
             });


### PR DESCRIPTION
Anytime someone uses the back button on the model details controller all models are reloaded. I try to fix that with this change. I could not find direct side effects. But it mark it as workaround because it looks not that great to have multiple variables to store the same values.