### PR TITLE
Allow to mark a property nullable

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
@@ -129,10 +129,14 @@ Constraint:
 	type = ConstraintIntervalType constraintValues = IntervalType
 ;
 
-enum ConstraintIntervalType: min = 'MIN' | max = 'MAX' | strlen = 'STRLEN' | regex = 'REGEX' | mimetype = 'MIMETYPE' | scaling = 'SCALING' | default = 'DEFAULT'; 
+enum ConstraintIntervalType: min = 'MIN' | max = 'MAX' | strlen = 'STRLEN' | regex = 'REGEX' | mimetype = 'MIMETYPE' | scaling = 'SCALING' | default = 'DEFAULT' | nullable = 'NULLABLE' ; 
 
 IntervalType:
-	INT | SIGNEDINT | FLOAT | DATETIME | STRING
+	INT | SIGNEDINT | FLOAT | DATETIME | STRING | BOOLEAN
+;
+
+BOOLEAN:
+	'true' | 'false'
 ;
 
 CATEGORY: ID ('/' ID)*;

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/internal/validation/NullableValueValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/internal/validation/NullableValueValidator.xtend
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+package org.eclipse.vorto.editor.datatype.internal.validation
+
+import org.eclipse.vorto.core.api.model.datatype.Constraint
+import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
+
+class NullableValueValidator extends ConstraintValueValidator {
+	
+	override evaluateValueType(PrimitiveType type, Constraint constraint) {
+		//currently no known restriction on this content
+		true
+	}
+	
+}

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/ConstraintValidatorFactory.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/ConstraintValidatorFactory.xtend
@@ -21,6 +21,7 @@ import org.eclipse.vorto.editor.datatype.internal.validation.AccordinglyValueVal
 import org.eclipse.vorto.editor.datatype.internal.validation.ConstraintValueValidator
 import org.eclipse.vorto.editor.datatype.internal.validation.RegexValueValidator
 import org.eclipse.vorto.editor.datatype.internal.validation.ScalarValueValidator
+import org.eclipse.vorto.editor.datatype.internal.validation.NullableValueValidator
 
 class ConstraintValidatorFactory {
 	
@@ -41,6 +42,8 @@ class ConstraintValidatorFactory {
 					new ScalarValueValidator 
 				case 'DEFAULT' :
 					new AccordinglyValueValidator
+				case 'NULLABLE' :
+					new NullableValueValidator
 				default:
 					throw new IllegalArgumentException('Not supported constraint type')
 			}

--- a/framework/org.eclipse.vorto.core/model/Datatype.ecore
+++ b/framework/org.eclipse.vorto.core/model/Datatype.ecore
@@ -53,6 +53,7 @@
     <eLiterals name="mimetype" value="4" literal="MIMETYPE"/>
     <eLiterals name="scaling" value="5" literal="SCALING"/>
     <eLiterals name="default" value="6" literal="DEFAULT"/>
+    <eLiterals name="nullable" value="7" literal="NULLABLE"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Enum" eSuperTypes="#//Type">
     <eStructuralFeatures xsi:type="ecore:EReference" name="enums" upperBound="-1"


### PR DESCRIPTION
To validate transmitted data it can be helpful to know if it is desired that the value is `null`.

Here is a example where primitive types and also complex types can be marked as nullable:
```
...
  status{
    mandatory deviceId as int <MIN 1, MAX 54>
    mandatory temperature as float <MIN -40, MAX 123.8, NULLABLE true>
    mandatory movement as ComplexMovementType <NULLABLE true>
    mandatory voltage as float <MIN 0, MAX 3.2, NULLABLE false>
  }
...
```