### PR TITLE
Fixed where NULLABLE was highlighted as syntax error

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/PropertyConstraintMappingValidation.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/validation/PropertyConstraintMappingValidation.xtend
@@ -1,19 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2014,2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- *
+ * 
  * The Eclipse Public License is available at
  * http://www.eclipse.org/legal/epl-v10.html
  * The Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *
+ * 
  * Contributors:
  * Bosch Software Innovations GmbH - Please refer to git log
- *
+ * 
  *******************************************************************************/
- 
+
 package org.eclipse.vorto.editor.datatype.validation
 
 import org.eclipse.vorto.core.api.model.datatype.Constraint
@@ -29,7 +29,6 @@ class PropertyConstraintMappingValidation {
 	val String[] strArr = #["STRLEN", "REGEX", "DEFAULT"]
 	val String[] mimeArr = #["MIMETYPE"]
 	val String[] byteArr = intervalArr + mimeArr
-	val String[] empty = #[]
 
 	private val valueTypeMap = <String, String[]>newHashMap(
 		'int' -> intervalArr,
@@ -42,16 +41,18 @@ class PropertyConstraintMappingValidation {
 		'string' -> strArr,
 		'boolean' -> boolArr,
 		'base64Binary' -> mimeArr
-		
 	);
 
 	def final boolean checkPropertyConstraints(PrimitiveType type, Constraint cons) {
 		var arr = valueTypeMap.get(type.literal)
-		if (arr == null || !arr.contains(cons.type.literal)) {
+		if (cons.type.literal.toUpperCase().equals("NULLABLE")) {
+			return true
+		}
+		if (arr === null || !arr.contains(cons.type.literal)) {
 			setErrorMessage(DatatypeSystemMessage.ERROR_CONSTRAINTTYPE_INVALID)
 			return false
 		}
-		true
+		return true
 	}
 
 	def String getErrorMessage() {


### PR DESCRIPTION
Missed this check in my first pull request. Now fixed.

Before:
![image](https://user-images.githubusercontent.com/209893/36845882-b3258b28-1d58-11e8-9ac7-ce11781d244a.png)
