### PR TITLE
Updated dependencies and added default values to local conf

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -230,18 +230,18 @@
 			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-annotations</artifactId>
-				<version>1.5.6</version>
+				<version>1.5.18</version>
 			</dependency>
 			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-models</artifactId>
-				<version>1.5.6</version>
+				<version>1.5.18</version>
 			</dependency>
 
 			<dependency>
 				<groupId>io.springfox</groupId>
 				<artifactId>springfox-swagger2</artifactId>
-				<version>2.3.0</version>
+				<version>2.8.0</version>
 			</dependency>
 
 			<dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -230,18 +230,18 @@
 			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-annotations</artifactId>
-				<version>1.5.18</version>
+				<version>1.5.17</version>
 			</dependency>
 			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-models</artifactId>
-				<version>1.5.18</version>
+				<version>1.5.17</version>
 			</dependency>
 
 			<dependency>
 				<groupId>io.springfox</groupId>
 				<artifactId>springfox-swagger2</artifactId>
-				<version>2.8.0</version>
+				<version>2.6.1</version>
 			</dependency>
 
 			<dependency>

--- a/server/repo/repository-mapping/pom.xml
+++ b/server/repo/repository-mapping/pom.xml
@@ -33,10 +33,6 @@
 			<artifactId>commons-text</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-text</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
 		</dependency>

--- a/server/repo/repository-web/pom.xml
+++ b/server/repo/repository-web/pom.xml
@@ -110,6 +110,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.0.0.RELEASE</version>
 				<executions>
 					<execution>
 						<goals>
@@ -129,6 +130,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/server/repo/repository-web/src/main/resources/application-local.yml
+++ b/server/repo/repository-web/src/main/resources/application-local.yml
@@ -43,6 +43,10 @@ webEditor:
 
 mail:
   smtp:
+    auth: false
     host: localhost
     port: 25
   from: vorto-dev@eclipse.org
+  login:
+    username: 
+    password: 


### PR DESCRIPTION
The ModelHandle definition is missing in http://vorto.eclipse.org/v2/api-docs. Because of a bug in `springfox-swagger2`(see: https://github.com/springfox/springfox/issues/1282)

Currently the api doc is invalid. Error in Swagger:
<img width="615" alt="screenshot_328" src="https://user-images.githubusercontent.com/209893/38109614-ffe005c8-3398-11e8-8285-327d7f60ebef.png">
