### PR TITLE
Fix source format in eclipse for functionblock, etc.

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/DatatypeRuntimeModule.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/DatatypeRuntimeModule.xtend
@@ -41,6 +41,6 @@ class DatatypeRuntimeModule extends AbstractDatatypeRuntimeModule {
 	}
 	
 	override bindIFormatter() {
-		DatatypeFormatter
+		return DatatypeFormatter
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/FunctionblockRuntimeModule.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/FunctionblockRuntimeModule.xtend
@@ -64,6 +64,6 @@ class FunctionblockRuntimeModule extends AbstractFunctionblockRuntimeModule {
 	}
 
 	override bindIFormatter() {
-		FunctionblockFormatter
+		return FunctionblockFormatter
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModelRuntimeModule.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModelRuntimeModule.xtend
@@ -50,6 +50,6 @@ class InformationModelRuntimeModule extends org.eclipse.vorto.editor.infomodel.A
 	}
 	
 	override bindIFormatter(){
-		InformationModelFormatter
+		return InformationModelFormatter
 	}
 }


### PR DESCRIPTION
For me the `Source -> Format` in Eclipse had no effect for a functionblock. After some research I have found in the Xtext unit tests (see [Link](https://github.com/TemenosDS/xtext-core/blob/3ba9c9fa57932cb81cac113e0c6a0d4ff9daf553/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/FormatterTestLanguageRuntimeModule.java)) that `bindIFormatter` needs a return statement.