### PR TITLE
Fixes #857 - Removes line wraps before property description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ generated-sources
 *.orig
 
 devtool-project-repository/
-
-.idea
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ generated-sources
 *.orig
 
 devtool-project-repository/
+
+.idea
+*.iml

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
@@ -82,5 +82,9 @@ class DatatypeFormatter extends AbstractDeclarativeFormatter {
 		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)	
 		
 		c.setNoSpace().before(f.enumAccess.commaKeyword_11_1_0)
+		
+		//Property description
+		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_7)
+		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_7)
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
@@ -82,9 +82,5 @@ class DatatypeFormatter extends AbstractDeclarativeFormatter {
 		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)	
 		
 		c.setNoSpace().before(f.enumAccess.commaKeyword_11_1_0)
-		
-		//Property description
-		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_7)
-		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_7)
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
@@ -86,5 +86,8 @@ class FunctionblockFormatter extends AbstractDeclarativeFormatter {
 		c.setNoSpace().before(f.operationAccess.commaKeyword_4_1_0)
 		c.setLinewrap(1).after(f.operationAccess.commaKeyword_4_1_0)
 		
+		//Property description
+		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_7)
+		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_7)
 	}
 }


### PR DESCRIPTION
This removes additional line breaks which are introduced by the braced rule. Adds two line breaks after a description.  

This fixes #857 