### PR TITLE
Fixes #912 : NullPointerException thrown when the model is invalid

### DIFF
--- a/framework/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/ui/model/AbstractModelElement.java
+++ b/framework/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/ui/model/AbstractModelElement.java
@@ -25,6 +25,7 @@ import java.util.TreeSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.vorto.core.api.model.model.Model;
 import org.eclipse.vorto.core.api.model.model.ModelId;
 import org.eclipse.vorto.core.api.model.model.ModelIdFactory;
 import org.eclipse.vorto.core.api.model.model.ModelReference;
@@ -67,7 +68,11 @@ public abstract class AbstractModelElement implements IModelElement,
 	
 	@Override
 	public ModelId getId() {
-		return ModelIdFactory.newInstance(getModel());
+		Model model = getModel();
+		if(model != null) {
+			return ModelIdFactory.newInstance(model);
+		}
+		return null;
 	}
 
 	@Override
@@ -77,7 +82,11 @@ public abstract class AbstractModelElement implements IModelElement,
 	
 	public Set<IModelElement> getReferences() {
 		Set<IModelElement> references = new TreeSet<>();
-		for (ModelReference modelReference : getModel().getReferences()) {
+		Model model = getModel();
+		if(model == null) {
+			return references;
+		}
+		for (ModelReference modelReference : model.getReferences()) {
 			for(ModelType possibleType : getPossibleReferenceTypes()) {
 				ModelId modelId = ModelIdFactory.newInstance(possibleType, modelReference);
 				IModelElement modelElementReference = this.modelProject.getModelElementById(modelId);

--- a/framework/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/labelprovider/DefaultTreeModelLabelProvider.java
+++ b/framework/org.eclipse.vorto.perspective/src/org/eclipse/vorto/perspective/labelprovider/DefaultTreeModelLabelProvider.java
@@ -17,6 +17,7 @@ package org.eclipse.vorto.perspective.labelprovider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.vorto.core.api.model.model.ModelId;
 import org.eclipse.vorto.core.ui.model.IModelElement;
 
 public class DefaultTreeModelLabelProvider extends ColumnLabelProvider {
@@ -54,7 +55,9 @@ public class DefaultTreeModelLabelProvider extends ColumnLabelProvider {
 	@Override
 	public String getText(Object element) {
 		IModelElement modelElement = (IModelElement) element;
-		return modelElement.getId().getName();
+		ModelId modelId = modelElement.getId();
+		// return filename if model is invalid
+		return modelId != null ? modelId.getName() : modelElement.getModelFile().getName();
 	}
 
 	@Override


### PR DESCRIPTION
If the Ecore model is invalid the filename is used as name.