### PR TITLE
Fixes #909 - Removed category and comments from templates

### DIFF
--- a/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/datatype/DataTypeFileTemplate.xtend
+++ b/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/datatype/DataTypeFileTemplate.xtend
@@ -37,9 +37,7 @@ class DataTypeFileTemplate implements ITemplate<IModelProjectContext> {
 		version «context.modelId.version»
 		displayname "«context.modelId.name»"
 		description "«context.modelDescription»"
-		category demo		
 		«typeName» «context.modelId.name» {
-			//Enter «typeName» details
 		}
 		'''
 	}

--- a/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/functionblock/FbmodelTemplateFileContent.xtend
+++ b/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/functionblock/FbmodelTemplateFileContent.xtend
@@ -27,25 +27,20 @@ class FbmodelTemplateFileContent implements ITemplate<IModelProjectContext> {
 	version «context.modelId.version»
 	displayname "«context.modelId.name»"
 	description "«context.modelDescription»"
-	category demo	
 	functionblock «context.modelId.name» {
 
-		configuration{ 
-			//Please enter functionblock configuration details.
+		configuration {
 		}
 
-		status{ 
-			//Please enter functionblock status details.
+		status {
 		}
 
-		fault{
-			//Please enter functionblock fault configuration.
+		fault {
 		}
 
-		operations{
-			//Please enter functionblock operations.
+		operations {
 		}
-	}	
+	}
 		'''
 	}
 	

--- a/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/infomodel/InfomodelTemplateFileContent.xtend
+++ b/bundles/org.eclipse.vorto.wizard.vorto/src/org/eclipse/vorto/wizard/infomodel/InfomodelTemplateFileContent.xtend
@@ -27,10 +27,8 @@ class InfomodelTemplateFileContent implements ITemplate<IModelProjectContext> {
 	version «context.modelId.version»
 	displayname "«context.modelId.name»"
 	description "«context.modelDescription»"
-	category demo	
 	infomodel «context.modelId.name» {
-
-	}	
+	}
 		'''
 	}
 


### PR DESCRIPTION
Fixes #909. I also removed the comments from the sections in a functionblock and some spaces. Those are removed anyway during development.