### PR TITLE
Fixes #908 - Using "dictonary" as type name with all lower case letters

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
@@ -116,7 +116,7 @@ ComplexPrimitivePropertyType:
 ;
 
 DictionaryPropertyType:
-	{DictionaryPropertyType} 'Dictionary' ('[' keyType = PropertyType ',' valueType = PropertyType ']')?
+	{DictionaryPropertyType} 'dictionary' ('[' keyType = PropertyType ',' valueType = PropertyType ']')?
 ;
 
 enum PrimitiveType: string = 'string' | int = 'int' | float =  'float' | boolean =  'boolean' | datetime = 'dateTime' | double = 'double' | long = 'long' | short = 'short' | base64Binary ='base64Binary' | byte = 'byte';


### PR DESCRIPTION
I have checked the repository and could not find any model which currently uses "Dictionary" as type.