### PR TITLE
Added extend feature to information model dsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ generated-sources
 *.orig
 
 devtool-project-repository/
+
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ generated-sources
 *.orig
 
 devtool-project-repository/
-
-*.iml

--- a/bundles/org.eclipse.vorto.editor.functionblock.tests/src/org/eclipse/vorto/editor/functionblock/tests/validator/FBExtendsTest.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock.tests/src/org/eclipse/vorto/editor/functionblock/tests/validator/FBExtendsTest.xtend
@@ -1,0 +1,56 @@
+package org.eclipse.vorto.editor.functionblock.tests.validator
+
+import org.eclipse.xtext.junit4.AbstractXtextTests
+import org.eclipse.xtext.junit4.validation.ValidatorTester
+import org.eclipse.vorto.editor.functionblock.validation.FunctionblockValidator
+import org.eclipse.vorto.editor.functionblock.FunctionblockStandaloneSetup
+import org.eclipse.vorto.core.api.model.functionblock.FunctionblockFactory
+import org.eclipse.vorto.core.api.model.datatype.DatatypeFactory
+import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
+import org.eclipse.vorto.editor.functionblock.validation.SystemMessage
+import org.junit.Test
+
+class FBExtendsTest extends AbstractXtextTests {
+		
+	private ValidatorTester<FunctionblockValidator> tester;
+	
+	def override void setUp() throws Exception {
+		super.setUp();
+		with(FunctionblockStandaloneSetup);
+		var validator = get(FunctionblockValidator);
+		tester = new ValidatorTester<FunctionblockValidator>(validator, getInjector());
+	}
+	
+	@Test
+	def test_IM_extend_datatype_conflict() {
+		var fbModel = FunctionblockFactory.eINSTANCE.createFunctionblockModel()
+		fbModel.functionblock = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		fbModel.functionblock.status = FunctionblockFactory.eINSTANCE.createStatus()
+		fbModel.name = "FB"
+		
+		var prop = DatatypeFactory.eINSTANCE.createProperty()
+		prop.name = "prop1"
+		var strType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType()
+		strType.setType(PrimitiveType.STRING)
+		prop.type = strType
+	
+		fbModel.functionblock.status.properties.add(prop)
+		
+		var extendedFb = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		extendedFb.status = FunctionblockFactory.eINSTANCE.createStatus()
+		var extProperty = DatatypeFactory.eINSTANCE.createProperty()
+		extProperty.name = "prop1"
+		var intType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType();
+		intType.setType(PrimitiveType.INT);
+		extProperty.type = intType	
+		extendedFb.status.properties.add(extProperty)
+		
+		var fbModelExtended = FunctionblockFactory.eINSTANCE.createFunctionblockModel()
+		fbModelExtended.functionblock = extendedFb
+		fbModelExtended.superType = fbModel
+		fbModelExtended.name = "FBextended"
+		
+		tester.validator().checkStatusOverriddenProperties(fbModelExtended)
+		tester.diagnose().assertErrorContains(SystemMessage.ERROR_INCOMPATIBLE_TYPE);
+	}
+}

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -53,6 +53,9 @@ import org.eclipse.vorto.core.api.model.functionblock.Param
 import org.eclipse.emf.ecore.util.EcoreUtil
 import java.util.ArrayList
 import org.eclipse.vorto.core.api.model.datatype.ConstraintIntervalType
+import org.eclipse.vorto.core.api.model.datatype.PropertyAttribute
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute
 
 /**
  * Custom validation rules. 
@@ -285,6 +288,27 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 		}
 	}
 
+	def validateOvewrittenPropertyAttr(Property baseProperty, Property extProperty) {
+		for (propAttr : extProperty.propertyAttributes) {
+			for (basePropAttr : baseProperty.propertyAttributes) {
+				if (propAttr instanceof BooleanPropertyAttribute && basePropAttr instanceof BooleanPropertyAttribute) {
+					if ((propAttr as BooleanPropertyAttribute).getType().equals(
+						(basePropAttr as BooleanPropertyAttribute).getType())) {
+						error(SystemMessage.ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE, extProperty,
+							DatatypePackage.Literals.PROPERTY__PROPERTY_ATTRIBUTES)
+					}
+				} else if (propAttr instanceof EnumLiteralPropertyAttribute &&
+					basePropAttr instanceof EnumLiteralPropertyAttribute) {
+					if ((propAttr as EnumLiteralPropertyAttribute).getType().getName().equals(
+						(basePropAttr as EnumLiteralPropertyAttribute).getType().getName())) {
+						error(SystemMessage.ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE, extProperty,
+							DatatypePackage.Literals.PROPERTY__PROPERTY_ATTRIBUTES)
+					}
+				}
+			}
+		}
+	}
+
 	def ArrayList<String> validateOverriddenConstraints(Property baseProperty, Property extProperty) {
 		var validatedConstraints = new ArrayList<String>()
 		if (baseProperty.constraintRule === null) {
@@ -353,6 +377,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 				if (!equalHelper.equals(property.type, baseProperty.type)) {
 					error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property, DatatypePackage.Literals.PROPERTY__TYPE)
 				}
+				validateOvewrittenPropertyAttr(baseProperty, property)
 				validatedConstraints.addAll(validateOverriddenConstraints(baseProperty, property))
 			}
 		}

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -68,9 +68,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 	@Check
 	def checkEntityandEnum(FunctionblockModel model) {
 		var list = getAllTypeFromReferencedFile(model);
-
 		var set = getNonDuplicateLowerCasedNameSet(list)
-
 		var entities = model.entities
 		var enums = model.enums
 
@@ -78,12 +76,10 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 			if (!set.add(en.name.toLowerCase))
 				error(SystemMessage.ERROR_TYPE_NAME_DUPLICATED, en, ModelPackage.Literals.MODEL__NAME)
 		}
-
 		for (en : enums) {
 			if (!set.add(en.name.toLowerCase))
 				error(SystemMessage.ERROR_TYPE_NAME_DUPLICATED, en, ModelPackage.Literals.MODEL__NAME)
 		}
-
 	}
 
 	def List<Type> getAllTypeFromReferencedFile(EObject eObject) {
@@ -164,6 +160,23 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 		}
 	}
 
+	def checkForConstraint(PrimitiveType primitiveType, Constraint constraint, EObject source, String parameterName,
+		boolean isMultiplcity, EStructuralFeature feature) {
+		if (!isValidConstraintType(primitiveType, constraint)) {
+			error(propertyValidator.errorMessage, source, feature)
+		} else {
+			var validator = ConstraintValidatorFactory.getValueValidator(constraint.type)
+			if (!isValidConstraintValue(validator, primitiveType, constraint)) {
+				error(validator.errorMessage, source, feature)
+			}
+		}
+		if (isMimeConstraint(parameterName, constraint)) {
+			if (!isMultiplcity) {
+				error(DatatypeSystemMessage.ERROR_MIMETYPE_FOR_BYTE, source, feature)
+			}
+		}
+	}
+
 	@Check
 	def checkParametersConstraint(Operation op) {
 		var parameters = op.params;
@@ -184,251 +197,232 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 	@Check
 	def checkReturnTypeConstraint(Operation op) {
 		var returnType = op.returnType
-		if (returnType instanceof ReturnPrimitiveType) {
-			var returnPrimitiveType = returnType as ReturnPrimitiveType
-			val parameterName = returnPrimitiveType.returnType.getName
-			var constraintsList = returnPrimitiveType.constraintRule.constraints
-			for (constraint : constraintsList) {
-				checkForConstraint(returnPrimitiveType.returnType, constraint, returnPrimitiveType, parameterName,
-					returnPrimitiveType.multiplicity,
-					FunctionblockPackage.Literals.RETURN_PRIMITIVE_TYPE__CONSTRAINT_RULE)
+		if (!(returnType instanceof ReturnPrimitiveType)) {
+			return
+		}
+		var returnPrimitiveType = returnType as ReturnPrimitiveType
+		val parameterName = returnPrimitiveType.returnType.getName
+		var constraintsList = returnPrimitiveType.constraintRule.constraints
+		for (constraint : constraintsList) {
+			checkForConstraint(returnPrimitiveType.returnType, constraint, returnPrimitiveType, parameterName,
+				returnPrimitiveType.multiplicity, FunctionblockPackage.Literals.RETURN_PRIMITIVE_TYPE__CONSTRAINT_RULE)
+		}
+	}
+
+	@Check
+	def checkPropsIn(Configuration c) {
+		checkDuplicatedProperty(c.properties)
+	}
+
+	@Check
+	def checkPropsIn(Status s) {
+		checkDuplicatedProperty(s.properties)
+	}
+
+	@Check
+	def checkPropsIn(Fault f) {
+		checkDuplicatedProperty(f.properties)
+	}
+
+	@Check
+	def checkPropsIn(Event e) {
+		checkDuplicatedProperty(e.properties)
+	}
+
+	@Check
+	def checkPropsIn(Entity e) {
+		checkDuplicatedProperty(e.properties)
+	}
+
+	@Check
+	def checkCircularRefInSuperType(FunctionblockModel functionblock) {
+		if (functionblock.superType !== null) {
+			try {
+				if (ValidatorUtils.hasCircularReference(functionblock, functionblock.superType,
+					FbValidatorUtils.modelToChildrenSupplierFunction)) {
+					error(DatatypeSystemMessage.ERROR_SUPERTYPE_CIRCULAR_REF, functionblock,
+						FunctionblockPackage.Literals.FUNCTIONBLOCK_MODEL__SUPER_TYPE);
 				}
-			}
-		}
-
-		def checkForConstraint(PrimitiveType primitiveType, Constraint constraint, EObject source, String parameterName,
-			boolean isMultiplcity, EStructuralFeature feature) {
-			if (!isValidConstraintType(primitiveType, constraint)) {
-				error(propertyValidator.errorMessage, source, feature)
-			} else {
-				var validator = ConstraintValidatorFactory.getValueValidator(constraint.type)
-				if (!isValidConstraintValue(validator, primitiveType, constraint)) {
-					error(validator.errorMessage, source, feature)
-				}
-			}
-			if (isMimeConstraint(parameterName, constraint)) {
-				if (!isMultiplcity) {
-					error(DatatypeSystemMessage.ERROR_MIMETYPE_FOR_BYTE, source, feature)
-				}
-			}
-		}
-
-		@Check
-		def checkPropsIn(Configuration c) {
-			checkDuplicatedProperty(c.properties)
-		}
-
-		@Check
-		def checkPropsIn(Status s) {
-			checkDuplicatedProperty(s.properties)
-		}
-
-		@Check
-		def checkPropsIn(Fault f) {
-			checkDuplicatedProperty(f.properties)
-		}
-
-		@Check
-		def checkPropsIn(Event e) {
-			checkDuplicatedProperty(e.properties)
-		}
-
-		@Check
-		def checkPropsIn(Entity e) {
-			checkDuplicatedProperty(e.properties)
-		}
-
-		@Check
-		def checkCircularRefInSuperType(FunctionblockModel functionblock) {
-			if (functionblock.superType !== null) {
-				try {
-					if (ValidatorUtils.hasCircularReference(functionblock, functionblock.superType,
-						FbValidatorUtils.modelToChildrenSupplierFunction)) {
-						error(DatatypeSystemMessage.ERROR_SUPERTYPE_CIRCULAR_REF, functionblock,
-							FunctionblockPackage.Literals.FUNCTIONBLOCK_MODEL__SUPER_TYPE);
-					}
-				} catch (Exception e) {
-					e.printStackTrace
-				}
-			}
-		}
-
-		@Check
-		def checkRefParamIsImported(RefParam refParam) {
-			val topParent = ValidatorUtils.getParentOfType(refParam, FunctionblockModel) as FunctionblockModel
-			if (topParent !== null && !ValidatorUtils.isTypeInReferences(refParam.type, topParent.references)) {
-				error(SystemMessage.ERROR_REF_PARAM_NOT_IMPORTED, refParam,
-					FunctionblockPackage.Literals.REF_PARAM__TYPE);
-			}
-		}
-
-		@Check
-		def checkReturnTypeIsImported(ReturnObjectType returnType) {
-			val topParent = ValidatorUtils.getParentOfType(returnType, FunctionblockModel) as FunctionblockModel
-			if (topParent !== null && !ValidatorUtils.isTypeInReferences(returnType.returnType, topParent.references)) {
-				error(SystemMessage.ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED, returnType,
-					FunctionblockPackage.Literals.RETURN_OBJECT_TYPE__RETURN_TYPE);
-			}
-		}
-
-		def setHelper(TypeHelper helper) {
-			this.helper = helper
-		}
-
-		def getHelper() {
-			this.helper
-		}
-
-		def String getPropertyName(PropertyType propertyType) {
-			if (propertyType instanceof PrimitivePropertyType) {
-				return propertyType.type.literal
-			} else if (propertyType instanceof DictionaryPropertyType) {
-				return "dict" + getPropertyName(propertyType.keyType) + getPropertyName(propertyType.valueType)
-			} else if (propertyType instanceof ObjectPropertyType) {
-				return propertyType.getType().name
-			}
-		}
-
-		def validateOverriddenProperties(EList<Property> properties, EList<Property> extProperties) {
-			var propertiesMap = properties.toMap[name].mapValues[it]
-
-			var equalHelper = new EcoreUtil.EqualityHelper()
-			for (property : extProperties) {
-				var baseProperty = propertiesMap.get(property.name)
-				if (baseProperty !== null) {
-					if (!equalHelper.equals(property.presence, baseProperty.presence)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, property,
-							DatatypePackage.Literals.PROPERTY__PRESENCE)
-					}
-					if (property.multiplicity != baseProperty.multiplicity) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_MULTIPLICITY, property,
-							DatatypePackage.Literals.PROPERTY__MULTIPLICITY)
-					}
-					if (!equalHelper.equals(property.type, baseProperty.type)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property, DatatypePackage.Literals.PROPERTY__TYPE)
-					}
-				}
-			}
-		}
-
-		def equalsParamList(List<Param> list1, List<Param> list2) {
-			var size = list1.size();
-			if (size != list2.size()) {
-				return false;
-			}
-			var equalHelper = new EcoreUtil.EqualityHelper();
-			for (var i = 0; i < size; i++) {
-				if (!equalHelper.equals(list1.get(i), list2.get(i))) {
-					return false;
-				}
-			}
-			return true;
-		}
-
-		def validateOverriddenOperations(EList<Operation> operations, EList<Operation> extOperations) {
-			var operationsMap = operations.toMap[name].mapValues[it]
-			var equalHelper = new EcoreUtil.EqualityHelper()
-
-			for (operation : extOperations) {
-
-				var baseOperation = operationsMap.get(operation.name)
-				if (baseOperation !== null) {
-					if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
-							FunctionblockPackage.Literals.OPERATION__PRESENCE)
-					}
-					if (operation.breakable != baseOperation.breakable) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_BREAKABLE, operation,
-							FunctionblockPackage.Literals.OPERATION__BREAKABLE)
-					}
-					if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
-							FunctionblockPackage.Literals.OPERATION__PRESENCE)
-					}
-					if (!equalsParamList(operation.params, baseOperation.params)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_PARMS, operation,
-							FunctionblockPackage.Literals.OPERATION__PARAMS)
-					}
-					if (!equalHelper.equals(operation.returnType, baseOperation.returnType)) {
-						error(SystemMessage.ERROR_INCOMPATIBLE_RETURN_TYPE, operation,
-							FunctionblockPackage.Literals.OPERATION__RETURN_TYPE)
-					}
-				}
-			}
-		}
-
-		def validateOverriddenEvents(EList<Event> events, EList<Event> extEvents) {
-			var eventsMap = events.toMap[name].mapValues[it]
-			for (event : extEvents) {
-				var baseEvent = eventsMap.get(event.name)
-				if (baseEvent !== null) {
-					validateOverriddenProperties(baseEvent.properties, event.properties)
-				}
-			}
-		}
-
-		def getParentFunctionBlocks(FunctionblockModel baseFunctionblockModel) {
-			var functionBlocks = new ArrayList<FunctionBlock>()
-			var lastFunctionblockModel = baseFunctionblockModel
-			while (lastFunctionblockModel.superType !== null) {
-				if (lastFunctionblockModel === lastFunctionblockModel.superType) {
-					return functionBlocks
-				}
-				lastFunctionblockModel = lastFunctionblockModel.superType
-				functionBlocks.add(lastFunctionblockModel.functionblock)
-			}
-			return functionBlocks
-		}
-
-		@Check
-		def checkConfigurationOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
-			var baseFb = baseFunctionblockModel.functionblock;
-			var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
-			for (parentFb : parentFunctionBlocks) {
-				if (parentFb.configuration !== null && baseFb.configuration !== null) {
-					validateOverriddenProperties(parentFb.configuration.properties, baseFb.configuration.properties)
-				}
-			}
-		}
-
-		@Check
-		def checkStatusOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
-			var baseFb = baseFunctionblockModel.functionblock;
-			var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
-			for (parentFb : parentFunctionBlocks) {
-				if (parentFb.status !== null && baseFb.status !== null) {
-					validateOverriddenProperties(parentFb.status.properties, baseFb.status.properties)
-				}
-			}
-		}
-
-		@Check
-		def checkFaultOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
-			var baseFb = baseFunctionblockModel.functionblock;
-			var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
-			for (parentFb : parentFunctionBlocks) {
-				if (parentFb.fault !== null && baseFb.fault !== null) {
-					validateOverriddenProperties(parentFb.fault.properties, baseFb.fault.properties)
-				}
-			}
-		}
-
-		@Check
-		def checkEventsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
-			var baseFb = baseFunctionblockModel.functionblock;
-			var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
-			for (parentFb : parentFunctionBlocks) {
-				validateOverriddenEvents(parentFb.events, baseFb.events)
-			}
-		}
-
-		@Check
-		def checkOperationsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
-			var baseFb = baseFunctionblockModel.functionblock;
-			var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
-			for (parentFb : parentFunctionBlocks) {
-				validateOverriddenOperations(parentFb.operations, baseFb.operations)
+			} catch (Exception e) {
+				e.printStackTrace
 			}
 		}
 	}
-	
+
+	@Check
+	def checkRefParamIsImported(RefParam refParam) {
+		val topParent = ValidatorUtils.getParentOfType(refParam, FunctionblockModel) as FunctionblockModel
+		if (topParent !== null && !ValidatorUtils.isTypeInReferences(refParam.type, topParent.references)) {
+			error(SystemMessage.ERROR_REF_PARAM_NOT_IMPORTED, refParam, FunctionblockPackage.Literals.REF_PARAM__TYPE);
+		}
+	}
+
+	@Check
+	def checkReturnTypeIsImported(ReturnObjectType returnType) {
+		val topParent = ValidatorUtils.getParentOfType(returnType, FunctionblockModel) as FunctionblockModel
+		if (topParent !== null && !ValidatorUtils.isTypeInReferences(returnType.returnType, topParent.references)) {
+			error(SystemMessage.ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED, returnType,
+				FunctionblockPackage.Literals.RETURN_OBJECT_TYPE__RETURN_TYPE);
+		}
+	}
+
+	def setHelper(TypeHelper helper) {
+		this.helper = helper
+	}
+
+	def getHelper() {
+		this.helper
+	}
+
+	def String getPropertyName(PropertyType propertyType) {
+		if (propertyType instanceof PrimitivePropertyType) {
+			return propertyType.type.literal
+		} else if (propertyType instanceof DictionaryPropertyType) {
+			return "dict" + getPropertyName(propertyType.keyType) + getPropertyName(propertyType.valueType)
+		} else if (propertyType instanceof ObjectPropertyType) {
+			return propertyType.getType().name
+		}
+	}
+
+	def validateOverriddenProperties(EList<Property> properties, EList<Property> extProperties) {
+		var propertiesMap = properties.toMap[name].mapValues[it]
+
+		var equalHelper = new EcoreUtil.EqualityHelper()
+		for (property : extProperties) {
+			var baseProperty = propertiesMap.get(property.name)
+			if (baseProperty !== null) {
+				if (!equalHelper.equals(property.presence, baseProperty.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, property,
+						DatatypePackage.Literals.PROPERTY__PRESENCE)
+				}
+				if (property.multiplicity != baseProperty.multiplicity) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_MULTIPLICITY, property,
+						DatatypePackage.Literals.PROPERTY__MULTIPLICITY)
+				}
+				if (!equalHelper.equals(property.type, baseProperty.type)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property, DatatypePackage.Literals.PROPERTY__TYPE)
+				}
+			}
+		}
+	}
+
+	def equalsParamList(List<Param> list1, List<Param> list2) {
+		var size = list1.size();
+		if (size != list2.size()) {
+			return false;
+		}
+		var equalHelper = new EcoreUtil.EqualityHelper();
+		for (var i = 0; i < size; i++) {
+			if (!equalHelper.equals(list1.get(i), list2.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	def validateOverriddenOperations(EList<Operation> operations, EList<Operation> extOperations) {
+		var operationsMap = operations.toMap[name].mapValues[it]
+		var equalHelper = new EcoreUtil.EqualityHelper()
+
+		for (operation : extOperations) {
+
+			var baseOperation = operationsMap.get(operation.name)
+			if (baseOperation !== null) {
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (operation.breakable != baseOperation.breakable) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_BREAKABLE, operation,
+						FunctionblockPackage.Literals.OPERATION__BREAKABLE)
+				}
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (!equalsParamList(operation.params, baseOperation.params)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PARMS, operation,
+						FunctionblockPackage.Literals.OPERATION__PARAMS)
+				}
+				if (!equalHelper.equals(operation.returnType, baseOperation.returnType)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_RETURN_TYPE, operation,
+						FunctionblockPackage.Literals.OPERATION__RETURN_TYPE)
+				}
+			}
+		}
+	}
+
+	def validateOverriddenEvents(EList<Event> events, EList<Event> extEvents) {
+		var eventsMap = events.toMap[name].mapValues[it]
+		for (event : extEvents) {
+			var baseEvent = eventsMap.get(event.name)
+			if (baseEvent !== null) {
+				validateOverriddenProperties(baseEvent.properties, event.properties)
+			}
+		}
+	}
+
+	def getParentFunctionBlocks(FunctionblockModel baseFunctionblockModel) {
+		var functionBlocks = new ArrayList<FunctionBlock>()
+		var lastFunctionblockModel = baseFunctionblockModel
+		while (lastFunctionblockModel.superType !== null) {
+			if (lastFunctionblockModel === lastFunctionblockModel.superType) {
+				return functionBlocks
+			}
+			lastFunctionblockModel = lastFunctionblockModel.superType
+			functionBlocks.add(lastFunctionblockModel.functionblock)
+		}
+		return functionBlocks
+	}
+
+	@Check
+	def checkConfigurationOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.configuration !== null && baseFb.configuration !== null) {
+				validateOverriddenProperties(parentFb.configuration.properties, baseFb.configuration.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkStatusOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.status !== null && baseFb.status !== null) {
+				validateOverriddenProperties(parentFb.status.properties, baseFb.status.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkFaultOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.fault !== null && baseFb.fault !== null) {
+				validateOverriddenProperties(parentFb.fault.properties, baseFb.fault.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkEventsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			validateOverriddenEvents(parentFb.events, baseFb.events)
+		}
+	}
+
+	@Check
+	def checkOperationsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			validateOverriddenOperations(parentFb.operations, baseFb.operations)
+		}
+	}
+}

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
@@ -35,5 +35,12 @@ class SystemMessage {
 	public static final String ERROR_REF_PARAM_NOT_IMPORTED = "Reference parameter has not yet been imported.";
 	
 	public static final String ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED = "Return type has not yet been imported.";
+	
+	public static final String ERROR_INCOMPATIBLE_TYPE = 'The property type is incompatible to base type.'
+	public static final String ERROR_INCOMPATIBLE_PRESENCE = 'The presence is incompatible to presence of the base type.'
+	public static final String ERROR_INCOMPATIBLE_MULTIPLICITY = 'The multiplicity is incompatible to multiplicity of the base type.'
+	public static final String ERROR_INCOMPATIBLE_BREAKABLE = 'The breakable definition is incompatible to base operation.'
+	public static final String ERROR_INCOMPATIBLE_PARMS = 'The parameters are incompatible to base operation parameters.'
+	public static final String ERROR_INCOMPATIBLE_RETURN_TYPE = 'The return type is incompatible to base type.'
 	
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
@@ -43,4 +43,10 @@ class SystemMessage {
 	public static final String ERROR_INCOMPATIBLE_PARMS = 'The parameters are incompatible to base operation parameters.'
 	public static final String ERROR_INCOMPATIBLE_RETURN_TYPE = 'The return type is incompatible to base type.'
 	
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_MIN_TOO_SMALL = 'The given MIN constraint needs to be bigger or equal as the base MIN value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_MAX_TOO_BIG = 'The given MAX constraint needs to be smaller or equal as the base MAX value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_NULLABLE = 'If the constraint NULLABLE of the base type is false than it can not changed.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_STRLEN = 'The given STRLEN constraint needs to be smaller or equal as the base STRLEN value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_ALREADY_DEFINED = 'The constraint is already defined in the base property.'
+	
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
@@ -48,5 +48,5 @@ class SystemMessage {
 	public static final String ERROR_OVERWRITTEN_CONSTRAINT_NULLABLE = 'If the constraint NULLABLE of the base type is false than it can not changed.'
 	public static final String ERROR_OVERWRITTEN_CONSTRAINT_STRLEN = 'The given STRLEN constraint needs to be smaller or equal as the base STRLEN value.'
 	public static final String ERROR_OVERWRITTEN_CONSTRAINT_ALREADY_DEFINED = 'The constraint is already defined in the base property.'
-	
+	public static final String ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE = 'Property attributes can not be overwritten.'
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.vorto.editor.infomodel.ide/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.vorto.editor.infomodel,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
- org.eclipse.vorto.editor.datatype
+ org.eclipse.vorto.editor.datatype,
+ org.eclipse.vorto.editor.functionblock
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.vorto.editor.infomodel.ide.contentassist.a
  ntlr.internal,org.eclipse.vorto.editor.infomodel.ide.contentassist.an

--- a/bundles/org.eclipse.vorto.editor.infomodel.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.vorto.editor.infomodel.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.vorto.editor.infomodel,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.vorto.editor.functionblock,
- org.eclipse.vorto.editor.functionblock.tests
+ org.eclipse.vorto.editor.functionblock.tests,
+ org.eclipse.vorto.editor.datatype;bundle-version="0.10.0"
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.formatting,
  org.hamcrest.core,
@@ -22,5 +23,5 @@ Import-Package: org.apache.log4j,
  org.junit.runners;version="4.5.0",
  org.junit.runners.model;version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ClassPath: resources/,.
+Bundle-ClassPath: .
 Export-Package: org.eclipse.vorto.editor.infomodel.tests

--- a/bundles/org.eclipse.vorto.editor.infomodel.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.vorto.editor.infomodel.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,9 @@ Require-Bundle: org.eclipse.vorto.editor.infomodel,
  org.eclipse.xtext.junit4,
  org.eclipse.vorto.core,
  org.eclipse.xtext.xbase.junit,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.vorto.editor.functionblock,
+ org.eclipse.vorto.editor.functionblock.tests
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.formatting,
  org.hamcrest.core,

--- a/bundles/org.eclipse.vorto.editor.infomodel.tests/src/org/eclipse/vorto/editor/infomodel/tests/validation/IMExtendTest.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel.tests/src/org/eclipse/vorto/editor/infomodel/tests/validation/IMExtendTest.xtend
@@ -1,0 +1,89 @@
+package org.eclipse.vorto.editor.infomodel.tests.validation
+
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+import org.eclipse.vorto.core.api.model.datatype.DatatypeFactory
+import org.eclipse.vorto.core.api.model.functionblock.FunctionblockFactory
+import org.eclipse.vorto.editor.functionblock.validation.SystemMessage
+import org.eclipse.xtext.junit4.AbstractXtextTests
+import org.eclipse.xtext.junit4.validation.ValidatorTester
+import org.junit.After
+import org.junit.Test
+import org.eclipse.vorto.editor.infomodel.InformationModelStandaloneSetup
+import org.eclipse.vorto.editor.infomodel.validation.InformationModelValidator
+import org.eclipse.vorto.core.api.model.informationmodel.InformationModelFactory
+import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
+import org.eclipse.vorto.editor.functionblock.FunctionblockStandaloneSetup
+
+class IMExtendTest extends AbstractXtextTests {
+	
+	private ValidatorTester<InformationModelValidator> tester;
+
+	def override void setUp() throws Exception {
+		super.setUp();
+		with(FunctionblockStandaloneSetup);
+		with(InformationModelStandaloneSetup);
+		var validator = get(InformationModelValidator);
+		tester = new ValidatorTester<InformationModelValidator>(validator, getInjector());		
+	}
+	
+	/**
+	 * Need to overwrite tearDown method to avoid emf classes get de-registered causing inconsistency between test methods
+	 * as static variable in *PackageImpl already set to true and it's not re-inited again
+	 */
+    @After
+	def override void tearDown() throws Exception {
+		
+	}
+		
+	@Test
+	def test_IM_extend_datatype_conflict() {
+		var fbModel = FunctionblockFactory.eINSTANCE.createFunctionblockModel()
+		fbModel.functionblock = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		fbModel.functionblock.status = FunctionblockFactory.eINSTANCE.createStatus()
+		fbModel.name = "FB"
+		
+		var prop = DatatypeFactory.eINSTANCE.createProperty()
+		prop.name = "prop1"
+		var strType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType()
+		strType.setType(PrimitiveType.STRING)
+		prop.type = strType
+	
+		fbModel.functionblock.status.properties.add(prop)
+		
+		var extendedFb = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		extendedFb.status = FunctionblockFactory.eINSTANCE.createStatus()
+		var extProperty = DatatypeFactory.eINSTANCE.createProperty()
+		extProperty.name = "prop1"
+		var intType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType();
+		intType.setType(PrimitiveType.INT);
+		extProperty.type = intType	
+		extendedFb.status.properties.add(extProperty)
+		
+		var fbProperty = InformationModelFactory.eINSTANCE.createFunctionblockProperty()
+		fbProperty.name = "fb1"
+		fbProperty.type = fbModel
+		fbProperty.extendedFunctionBlock = extendedFb
+		
+		var imModel = InformationModelFactory.eINSTANCE.createInformationModel()
+		imModel.name = "IM"
+		imModel.properties.add(fbProperty)
+		
+		tester.validator().checkStatusExtendOverriddenProperties(imModel)
+		tester.diagnose().assertErrorContains(SystemMessage.ERROR_INCOMPATIBLE_TYPE);
+	}
+}

--- a/bundles/org.eclipse.vorto.editor.infomodel.tests/src/org/eclipse/vorto/editor/infomodel/tests/validation/IMValidatorTest.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel.tests/src/org/eclipse/vorto/editor/infomodel/tests/validation/IMValidatorTest.xtend
@@ -1,0 +1,41 @@
+package org.eclipse.vorto.editor.infomodel.tests.validation
+
+import org.eclipse.xtext.junit4.AbstractXtextTests
+import org.eclipse.xtext.junit4.validation.ValidatorTester
+import org.eclipse.vorto.editor.infomodel.validation.InformationModelValidator
+import org.eclipse.vorto.editor.infomodel.InformationModelStandaloneSetup
+import org.junit.After
+import org.junit.Test
+import org.eclipse.vorto.core.api.model.informationmodel.InformationModelFactory
+import org.eclipse.vorto.editor.infomodel.validation.SystemMessage
+
+class IMValidatorTest extends AbstractXtextTests {
+	
+	private ValidatorTester<InformationModelValidator> tester;
+
+	def override void setUp() throws Exception {
+		super.setUp();
+		with(InformationModelStandaloneSetup);
+		var validator = get(InformationModelValidator);
+		tester = new ValidatorTester<InformationModelValidator>(validator, getInjector());		
+	}
+	
+	/**
+	 * Need to overwrite tearDown method to avoid emf classes get de-registered causing inconsistency between test methods
+	 * as static variable in *PackageImpl already set to true and it's not re-inited again
+	 */
+    @After
+	def override void tearDown() throws Exception {
+		
+	}
+	
+	@Test
+	def test_IMName() {
+		var imModel = InformationModelFactory.eINSTANCE.createInformationModel()		
+		imModel.setName("fame")
+		
+		tester.validator().checkInformationModelName(imModel)
+		tester.diagnose().assertErrorContains(SystemMessage.ERROR_IMNAME_INVALID);
+	}
+	
+}

--- a/bundles/org.eclipse.vorto.editor.infomodel.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.vorto.editor.infomodel.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.xtext.ui,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.vorto.editor.infomodel.ide,
- org.eclipse.vorto.editor.datatype.ui
+ org.eclipse.vorto.editor.datatype.ui,
+ org.eclipse.vorto.editor.functionblock.ui
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.vorto.editor.infomodel.ui.contentassist,or

--- a/bundles/org.eclipse.vorto.editor.infomodel/pom.xml
+++ b/bundles/org.eclipse.vorto.editor.infomodel/pom.xml
@@ -70,6 +70,17 @@
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.vorto</groupId>
+						<artifactId>org.eclipse.vorto.editor.functionblock</artifactId>
+						<version>${project.version}</version>
+						<exclusions>
+							<exclusion>
+								<groupId>p2.eclipse-plugin</groupId>
+								<artifactId>*</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.vorto</groupId>
 						<artifactId>org.eclipse.vorto.core</artifactId>
 						<version>${project.version}</version>
 						<exclusions>

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModel.xtext
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModel.xtext
@@ -13,11 +13,11 @@
  * Bosch Software Innovations GmbH - Please refer to git log
  *
  *******************************************************************************/
-grammar org.eclipse.vorto.editor.infomodel.InformationModel with org.eclipse.vorto.editor.datatype.Datatype
+grammar org.eclipse.vorto.editor.infomodel.InformationModel with org.eclipse.vorto.editor.functionblock.Functionblock
+
 
 import "http://www.eclipse.org/vorto/metamodel/InformationModel"
-import "http://www.eclipse.org/vorto/metamodel/Model" as model
-import "http://www.eclipse.org/vorto/metamodel/Functionblock" as fbs
+import "http://www.eclipse.org/vorto/metamodel/Functionblock" as fb
 
 InformationModel:
 	{InformationModel}
@@ -33,19 +33,9 @@ InformationModel:
 	'}')?
 	'}';
 
-CATEGORY:
-	ID ('/' ID)*;
-	
-QualifiedName:
-	ID ('.' ID)*
-;
-
 FunctionblockProperty:
-	(presence = Presence)? name = ID 'as' type = [fbs::FunctionblockModel|QualifiedName] (description=STRING)?
-;
-
-terminal VERSION : ('0'..'9')* '.' ('0'..'9')* '.' ('0'..'9')*('-'ID)?;
-
-ModelReference returns model::ModelReference: 
-	'using' importedNamespace=QualifiedName';'version=VERSION
+	(presence = Presence)? name = ID 'as' type = [fb::FunctionblockModel | QualifiedName] ('extend' '{' 
+		extendedFunctionBlock = FunctionBlock
+		'}'
+	)? (description=STRING)?
 ;

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModelRuntimeModule.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/InformationModelRuntimeModule.xtend
@@ -26,6 +26,9 @@ import org.eclipse.xtext.scoping.IScopeProvider
 import com.google.inject.Binder
 import com.google.inject.Singleton
 import org.eclipse.vorto.editor.infomodel.formatting.InformationModelFormatter
+import com.google.inject.Provides
+import org.eclipse.vorto.editor.functionblock.validation.TypeHelper
+import org.eclipse.vorto.editor.functionblock.validation.TypeFileAccessingHelper
 
 /** 
  * Use this class to register components to be used at runtime / without the
@@ -39,6 +42,10 @@ class InformationModelRuntimeModule extends org.eclipse.vorto.editor.infomodel.A
 
 	override Class<? extends IScopeProvider> bindIScopeProvider() {
 		return InformationModelScopeProvider
+	}
+	
+	@Provides def TypeHelper getTypeHelper() {
+		return new TypeFileAccessingHelper()
 	}
 
 	override Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
@@ -16,24 +16,11 @@
 package org.eclipse.vorto.editor.infomodel.validation
 
 import java.util.HashSet
-import org.eclipse.vorto.core.api.model.datatype.Property
 import org.eclipse.vorto.core.api.model.informationmodel.FunctionblockProperty
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModelPackage
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
-import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType
-import org.eclipse.vorto.core.api.model.datatype.PropertyType
-import org.eclipse.vorto.core.api.model.datatype.DictionaryPropertyType
-import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType
-import org.eclipse.vorto.core.api.model.datatype.DatatypePackage
-import org.eclipse.emf.common.util.EList
-import org.eclipse.emf.ecore.util.EcoreUtil
-import org.eclipse.vorto.core.api.model.functionblock.Operation
-import org.eclipse.vorto.core.api.model.functionblock.FunctionblockPackage
-import java.util.List
-import org.eclipse.vorto.core.api.model.functionblock.Param
-import org.eclipse.vorto.core.api.model.functionblock.Event
 
 /**
  * Information Model Validation rules. 
@@ -59,95 +46,6 @@ class InformationModelValidator extends AbstractInformationModelValidator {
 		if (topParent !== null && !ValidatorUtils.isTypeInReferences(property.type, topParent.references)) {
 			error(SystemMessage.ERROR_FUNCTIONBLOCK_NOT_IMPORTED, property,
 				InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__TYPE)
-		}
-	}
-
-	def String getPropertyName(PropertyType propertyType) {
-		if (propertyType instanceof PrimitivePropertyType) {
-			return propertyType.type.literal
-		} else if (propertyType instanceof DictionaryPropertyType) {
-			return "dict" + getPropertyName(propertyType.keyType) + getPropertyName(propertyType.valueType)
-		} else if (propertyType instanceof ObjectPropertyType) {
-			return propertyType.getType().name
-		}
-	}
-
-	def validateOverriddenProperties(EList<Property> properties, EList<Property> extProperties) {
-		var propertiesMap = properties.toMap[name].mapValues[it]
-
-		var equalHelper = new EcoreUtil.EqualityHelper()
-		for (property : extProperties) {
-			var baseProperty = propertiesMap.get(property.name)
-			if (baseProperty !== null) {
-				if (!equalHelper.equals(property.presence, baseProperty.presence)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, property,
-						DatatypePackage.Literals.PROPERTY__PRESENCE)
-				}
-				if (property.multiplicity != baseProperty.multiplicity) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_MULTIPLICITY, property,
-						DatatypePackage.Literals.PROPERTY__MULTIPLICITY)
-				}
-				if (!equalHelper.equals(property.type, baseProperty.type)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property,
-						DatatypePackage.Literals.PROPERTY__TYPE)
-				}
-			}
-		}
-	}
-
-	def equalsParamList(List<Param> list1, List<Param> list2) {
-		var size = list1.size();
-		if (size != list2.size()) {
-			return false;
-		}
-		var equalHelper = new EcoreUtil.EqualityHelper();
-		for (var i = 0; i < size; i++) {
-			if (!equalHelper.equals(list1.get(i), list2.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	def validateOverriddenOperations(EList<Operation> operations, EList<Operation> extOperations) {
-		var operationsMap = operations.toMap[name].mapValues[it]
-		var equalHelper = new EcoreUtil.EqualityHelper()
-
-		for (operation : extOperations) {
-
-			var baseOperation = operationsMap.get(operation.name)
-			if (baseOperation !== null) {
-				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
-						FunctionblockPackage.Literals.OPERATION__PRESENCE)
-				}
-				if (operation.breakable != baseOperation.breakable) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_BREAKABLE, operation,
-						FunctionblockPackage.Literals.OPERATION__BREAKABLE)
-				}
-				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
-						FunctionblockPackage.Literals.OPERATION__PRESENCE)
-				}
-				if (!equalsParamList(operation.params, baseOperation.params)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_PARMS, operation,
-						FunctionblockPackage.Literals.OPERATION__PARAMS)
-				}
-				if (!equalHelper.equals(operation.returnType, baseOperation.returnType)) {
-					error(SystemMessage.ERROR_INCOMPATIBLE_RETURN_TYPE, operation,
-						FunctionblockPackage.Literals.OPERATION__RETURN_TYPE)
-				}
-			}
-		}
-	}
-
-	def validateOverriddenEvents(EList<Event> events, EList<Event> extEvents) {
-		var eventsMap = events.toMap[name].mapValues[it]
-		for (event : extEvents) {
-			var baseEvent = eventsMap.get(event.name)
-			if (baseEvent !== null) {
-				validateOverriddenProperties(baseEvent.properties, event.properties)
-			}
 		}
 	}
 

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
@@ -22,6 +22,7 @@ import org.eclipse.vorto.core.api.model.informationmodel.InformationModelPackage
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
 import org.eclipse.vorto.core.api.model.model.ModelPackage
+import java.util.ArrayList
 
 /**
  * Information Model Validation rules. 
@@ -60,33 +61,36 @@ class InformationModelValidator extends AbstractInformationModelValidator {
 
 	@Check
 	def checkStatusExtendOverriddenProperties(InformationModel informationModel) {
+		var validatedConstraints = new ArrayList<String>()
 		for (fbProperty : informationModel.properties) {
 			if (fbProperty.extendedFunctionBlock !== null) {
 				var baseFb = fbProperty.type.functionblock;
 				var extendedFb = fbProperty.extendedFunctionBlock;
-				validateOverriddenProperties(baseFb.status.properties, extendedFb.status.properties)
+				validateOverriddenProperties(baseFb.status.properties, extendedFb.status.properties, validatedConstraints)
 			}
 		}
 	}
 
 	@Check
 	def checkConfigurationExtendOverriddenProperties(InformationModel informationModel) {
+		var validatedConstraints = new ArrayList<String>()
 		for (fbProperty : informationModel.properties) {
 			if (fbProperty.extendedFunctionBlock !== null) {
 				var baseFb = fbProperty.type.functionblock;
 				var extendedFb = fbProperty.extendedFunctionBlock;
-				validateOverriddenProperties(baseFb.configuration.properties, extendedFb.configuration.properties)
+				validateOverriddenProperties(baseFb.configuration.properties, extendedFb.configuration.properties, validatedConstraints)
 			}
 		}
 	}
 
 	@Check
 	def checkFaultExtendOverriddenProperties(InformationModel informationModel) {
+		var validatedConstraints = new ArrayList<String>()
 		for (fbProperty : informationModel.properties) {
 			if (fbProperty.extendedFunctionBlock !== null) {
 				var baseFb = fbProperty.type.functionblock;
 				var extendedFb = fbProperty.extendedFunctionBlock;
-				validateOverriddenProperties(baseFb.fault.properties, extendedFb.fault.properties)
+				validateOverriddenProperties(baseFb.fault.properties, extendedFb.fault.properties, validatedConstraints)
 			}
 		}
 	}

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
@@ -21,11 +21,20 @@ import org.eclipse.vorto.core.api.model.informationmodel.InformationModel
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModelPackage
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
+import org.eclipse.vorto.core.api.model.model.ModelPackage
 
 /**
  * Information Model Validation rules. 
  */
 class InformationModelValidator extends AbstractInformationModelValidator {
+	
+	@Check
+	def checkInformationModelName(InformationModel model) {
+		val name = model.name
+		if (isCamelCasedName(name)) {
+			error(SystemMessage.ERROR_IMNAME_INVALID, model, ModelPackage.Literals.MODEL__NAME)
+		}
+	}
 
 	@Check
 	def checkDuplicateFunctionBlock(InformationModel informationModel) {

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/InformationModelValidator.xtend
@@ -1,26 +1,39 @@
 /*******************************************************************************
- * Copyright (c) 2014 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- *
+ * 
  * The Eclipse Public License is available at
  * http://www.eclipse.org/legal/epl-v10.html
  * The Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *
+ * 
  * Contributors:
  * Bosch Software Innovations GmbH - Please refer to git log
- *
+ * 
  *******************************************************************************/
 package org.eclipse.vorto.editor.infomodel.validation
 
 import java.util.HashSet
+import org.eclipse.vorto.core.api.model.datatype.Property
 import org.eclipse.vorto.core.api.model.informationmodel.FunctionblockProperty
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModelPackage
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
+import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType
+import org.eclipse.vorto.core.api.model.datatype.PropertyType
+import org.eclipse.vorto.core.api.model.datatype.DictionaryPropertyType
+import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType
+import org.eclipse.vorto.core.api.model.datatype.DatatypePackage
+import org.eclipse.emf.common.util.EList
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.vorto.core.api.model.functionblock.Operation
+import org.eclipse.vorto.core.api.model.functionblock.FunctionblockPackage
+import java.util.List
+import org.eclipse.vorto.core.api.model.functionblock.Param
+import org.eclipse.vorto.core.api.model.functionblock.Event
 
 /**
  * Information Model Validation rules. 
@@ -29,21 +42,167 @@ class InformationModelValidator extends AbstractInformationModelValidator {
 
 	@Check
 	def checkDuplicateFunctionBlock(InformationModel informationModel) {
-		 var fbNamesSet = new HashSet<String>()
-		 var functionblockProperties = informationModel.properties
-		 for (var i = 0; i < functionblockProperties.length; i++) {
+		var fbNamesSet = new HashSet<String>()
+		var functionblockProperties = informationModel.properties
+		for (var i = 0; i < functionblockProperties.length; i++) {
 			var functionblockProperty = functionblockProperties.get(i)
 			if (!fbNamesSet.add(functionblockProperty.name)) {
-				error(SystemMessage.ERROR_DUPLICATED_FUNCTIONBLOCK_NAME, informationModel, InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__NAME)
+				error(SystemMessage.ERROR_DUPLICATED_FUNCTIONBLOCK_NAME, informationModel,
+					InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__NAME)
 			}
 		}
 	}
-	
+
 	@Check
 	def checkFunctionBlockIsImported(FunctionblockProperty property) {
 		val topParent = ValidatorUtils.getParentOfType(property, InformationModel) as InformationModel
-		if (topParent != null && !ValidatorUtils.isTypeInReferences(property.type, topParent.references)) {
-			error(SystemMessage.ERROR_FUNCTIONBLOCK_NOT_IMPORTED, property, InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__TYPE)
+		if (topParent !== null && !ValidatorUtils.isTypeInReferences(property.type, topParent.references)) {
+			error(SystemMessage.ERROR_FUNCTIONBLOCK_NOT_IMPORTED, property,
+				InformationModelPackage.Literals.FUNCTIONBLOCK_PROPERTY__TYPE)
+		}
+	}
+
+	def String getPropertyName(PropertyType propertyType) {
+		if (propertyType instanceof PrimitivePropertyType) {
+			return propertyType.type.literal
+		} else if (propertyType instanceof DictionaryPropertyType) {
+			return "dict" + getPropertyName(propertyType.keyType) + getPropertyName(propertyType.valueType)
+		} else if (propertyType instanceof ObjectPropertyType) {
+			return propertyType.getType().name
+		}
+	}
+
+	def validateOverriddenProperties(EList<Property> properties, EList<Property> extProperties) {
+		var propertiesMap = properties.toMap[name].mapValues[it]
+
+		var equalHelper = new EcoreUtil.EqualityHelper()
+		for (property : extProperties) {
+			var baseProperty = propertiesMap.get(property.name)
+			if (baseProperty !== null) {
+				if (!equalHelper.equals(property.presence, baseProperty.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, property,
+						DatatypePackage.Literals.PROPERTY__PRESENCE)
+				}
+				if (property.multiplicity != baseProperty.multiplicity) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_MULTIPLICITY, property,
+						DatatypePackage.Literals.PROPERTY__MULTIPLICITY)
+				}
+				if (!equalHelper.equals(property.type, baseProperty.type)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property,
+						DatatypePackage.Literals.PROPERTY__TYPE)
+				}
+			}
+		}
+	}
+
+	def equalsParamList(List<Param> list1, List<Param> list2) {
+		var size = list1.size();
+		if (size != list2.size()) {
+			return false;
+		}
+		var equalHelper = new EcoreUtil.EqualityHelper();
+		for (var i = 0; i < size; i++) {
+			if (!equalHelper.equals(list1.get(i), list2.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	def validateOverriddenOperations(EList<Operation> operations, EList<Operation> extOperations) {
+		var operationsMap = operations.toMap[name].mapValues[it]
+		var equalHelper = new EcoreUtil.EqualityHelper()
+
+		for (operation : extOperations) {
+
+			var baseOperation = operationsMap.get(operation.name)
+			if (baseOperation !== null) {
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (operation.breakable != baseOperation.breakable) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_BREAKABLE, operation,
+						FunctionblockPackage.Literals.OPERATION__BREAKABLE)
+				}
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (!equalsParamList(operation.params, baseOperation.params)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PARMS, operation,
+						FunctionblockPackage.Literals.OPERATION__PARAMS)
+				}
+				if (!equalHelper.equals(operation.returnType, baseOperation.returnType)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_RETURN_TYPE, operation,
+						FunctionblockPackage.Literals.OPERATION__RETURN_TYPE)
+				}
+			}
+		}
+	}
+
+	def validateOverriddenEvents(EList<Event> events, EList<Event> extEvents) {
+		var eventsMap = events.toMap[name].mapValues[it]
+		for (event : extEvents) {
+			var baseEvent = eventsMap.get(event.name)
+			if (baseEvent !== null) {
+				validateOverriddenProperties(baseEvent.properties, event.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkStatusExtendOverriddenProperties(InformationModel informationModel) {
+		for (fbProperty : informationModel.properties) {
+			if (fbProperty.extendedFunctionBlock !== null) {
+				var baseFb = fbProperty.type.functionblock;
+				var extendedFb = fbProperty.extendedFunctionBlock;
+				validateOverriddenProperties(baseFb.status.properties, extendedFb.status.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkConfigurationExtendOverriddenProperties(InformationModel informationModel) {
+		for (fbProperty : informationModel.properties) {
+			if (fbProperty.extendedFunctionBlock !== null) {
+				var baseFb = fbProperty.type.functionblock;
+				var extendedFb = fbProperty.extendedFunctionBlock;
+				validateOverriddenProperties(baseFb.configuration.properties, extendedFb.configuration.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkFaultExtendOverriddenProperties(InformationModel informationModel) {
+		for (fbProperty : informationModel.properties) {
+			if (fbProperty.extendedFunctionBlock !== null) {
+				var baseFb = fbProperty.type.functionblock;
+				var extendedFb = fbProperty.extendedFunctionBlock;
+				validateOverriddenProperties(baseFb.fault.properties, extendedFb.fault.properties)
+			}
+		}
+	}
+
+	@Check
+	def checkEventsExtendOverriddenProperties(InformationModel informationModel) {
+		for (fbProperty : informationModel.properties) {
+			if (fbProperty.extendedFunctionBlock !== null) {
+				var baseFb = fbProperty.type.functionblock;
+				var extendedFb = fbProperty.extendedFunctionBlock;
+				validateOverriddenEvents(baseFb.events, extendedFb.events)
+			}
+		}
+	}
+
+	@Check
+	def checkOverrideOperationType(InformationModel informationModel) {
+		for (fbProperty : informationModel.properties) {
+			if (fbProperty.extendedFunctionBlock !== null) {
+				var baseFb = fbProperty.type.functionblock;
+				var extendedFb = fbProperty.extendedFunctionBlock;
+				validateOverriddenOperations(baseFb.operations, extendedFb.operations)
+			}
 		}
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
@@ -20,4 +20,10 @@
 class SystemMessage {
 	public static final String ERROR_DUPLICATED_FUNCTIONBLOCK_NAME = 'Function Block is already defined'
 	public static final String ERROR_FUNCTIONBLOCK_NOT_IMPORTED = 'This Function Block has not yet been imported.'
+	public static final String ERROR_INCOMPATIBLE_TYPE = 'The property type is incompatible to base type.'
+	public static final String ERROR_INCOMPATIBLE_PRESENCE = 'The presence is incompatible to presence of the base type.'
+	public static final String ERROR_INCOMPATIBLE_MULTIPLICITY = 'The multiplicity is incompatible to multiplicity of the base type.'
+	public static final String ERROR_INCOMPATIBLE_BREAKABLE = 'The breakable definition is incompatible to base operation.'
+	public static final String ERROR_INCOMPATIBLE_PARMS = 'The parameters are incompatible to base operation parameters.'
+	public static final String ERROR_INCOMPATIBLE_RETURN_TYPE = 'The return type is incompatible to base type.'
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
@@ -20,4 +20,5 @@
 class SystemMessage {
 	public static final String ERROR_DUPLICATED_FUNCTIONBLOCK_NAME = 'Function Block is already defined'
 	public static final String ERROR_FUNCTIONBLOCK_NOT_IMPORTED = 'This Function Block has not yet been imported.'
+	public static final String ERROR_IMNAME_INVALID = 'Information model name must begin with a capital letter'
 }

--- a/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.infomodel/src/org/eclipse/vorto/editor/infomodel/validation/SystemMessage.xtend
@@ -20,10 +20,4 @@
 class SystemMessage {
 	public static final String ERROR_DUPLICATED_FUNCTIONBLOCK_NAME = 'Function Block is already defined'
 	public static final String ERROR_FUNCTIONBLOCK_NOT_IMPORTED = 'This Function Block has not yet been imported.'
-	public static final String ERROR_INCOMPATIBLE_TYPE = 'The property type is incompatible to base type.'
-	public static final String ERROR_INCOMPATIBLE_PRESENCE = 'The presence is incompatible to presence of the base type.'
-	public static final String ERROR_INCOMPATIBLE_MULTIPLICITY = 'The multiplicity is incompatible to multiplicity of the base type.'
-	public static final String ERROR_INCOMPATIBLE_BREAKABLE = 'The breakable definition is incompatible to base operation.'
-	public static final String ERROR_INCOMPATIBLE_PARMS = 'The parameters are incompatible to base operation parameters.'
-	public static final String ERROR_INCOMPATIBLE_RETURN_TYPE = 'The return type is incompatible to base type.'
 }

--- a/framework/org.eclipse.vorto.core/model/InformationModel.ecore
+++ b/framework/org.eclipse.vorto.core/model/InformationModel.ecore
@@ -12,5 +12,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass Functionblock.ecore#//FunctionblockModel"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="presence" eType="ecore:EClass Datatype.ecore#//Presence"
         containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="extendedFunctionBlock"
+        eType="ecore:EClass Functionblock.ecore#//FunctionBlock" containment="true"/>
   </eClassifiers>
 </ecore:EPackage>


### PR DESCRIPTION
As discussed in #823 it can be helpful to extend/override attributes of a function block in an information model. The `with` keyword is already used in another context to give a property additional attributes. Thats why the keyword `extend` is used. In and `extend` block all features of a function block can be used. Other like the proposed idea the fields status, etc. are retained because property names between sections are not unique. 

Example:
```
infomodel SenseHat {
    functionblocks {
        gyrometer as Gyrometer extend { 
            status {
                offline as boolean
            }
            operations {
                set_active()
            }
        }
    }
}
```

The feature could be implemented similar for data types in a function block in the future.