### PR TITLE
#1430: Fixed the clm issues. 

### DIFF
--- a/server/repo/repository-server/pom.xml
+++ b/server/repo/repository-server/pom.xml
@@ -98,6 +98,17 @@
 		<dependency>
 			<groupId>org.modeshape</groupId>
 			<artifactId>modeshape-jcr</artifactId>
+			<exclusions>
+        		<exclusion> 
+          			<groupId>org.apache.tika</groupId>
+         	 		<artifactId>tika-core</artifactId>
+        		</exclusion>
+      		</exclusions> 
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+			<version>1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.modeshape</groupId>


### PR DESCRIPTION
Excluded the apache tika core(1.6) default version  from modeshape-jcr and included the apache tika core (1.17) explicitly

Signed-off-by: Syam Sasidharan <syam.sasidharan@bosch-si.com>