### PR TITLE
Added validation for FB extends

### DIFF
--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
@@ -63,7 +63,7 @@ EnumLiteral:
 ;
 
 Property:
-	(presence = Presence)? (multiplicity ?= 'multiple')? name = ID 'as' type = PropertyType
+	(extension ?= 'extension')? (presence = Presence)? (multiplicity ?= 'multiple')? name = ID 'as' type = PropertyType
 	('with' '{' propertyAttributes+=PropertyAttribute (',' propertyAttributes+=PropertyAttribute)* '}')?
 	('<' constraintRule = ConstraintRule '>')?
 	(description=STRING)?

--- a/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/formatting/DatatypeFormatter.xtend
@@ -78,13 +78,13 @@ class DatatypeFormatter extends AbstractDeclarativeFormatter {
 		]
 				
 		//Constraint Parameters
-		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_3_0)
-		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)	
+		c.setNoSpace().before(f.propertyAccess.commaKeyword_6_3_0)
+		c.setNoSpace().after(f.propertyAccess.commaKeyword_6_3_0)	
 		
 		c.setNoSpace().before(f.enumAccess.commaKeyword_11_1_0)
 		
 		//Property description
-		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_7)
-		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_7)
+		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_8)
+		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_8)
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock.tests/src/org/eclipse/vorto/editor/functionblock/tests/validator/FBExtendsTest.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock.tests/src/org/eclipse/vorto/editor/functionblock/tests/validator/FBExtendsTest.xtend
@@ -1,0 +1,56 @@
+package org.eclipse.vorto.editor.functionblock.tests.validator
+
+import org.eclipse.xtext.junit4.AbstractXtextTests
+import org.eclipse.xtext.junit4.validation.ValidatorTester
+import org.eclipse.vorto.editor.functionblock.validation.FunctionblockValidator
+import org.eclipse.vorto.editor.functionblock.FunctionblockStandaloneSetup
+import org.eclipse.vorto.core.api.model.functionblock.FunctionblockFactory
+import org.eclipse.vorto.core.api.model.datatype.DatatypeFactory
+import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
+import org.eclipse.vorto.editor.functionblock.validation.SystemMessage
+import org.junit.Test
+
+class FBExtendsTest extends AbstractXtextTests {
+		
+	private ValidatorTester<FunctionblockValidator> tester;
+	
+	def override void setUp() throws Exception {
+		super.setUp();
+		with(FunctionblockStandaloneSetup);
+		var validator = get(FunctionblockValidator);
+		tester = new ValidatorTester<FunctionblockValidator>(validator, getInjector());
+	}
+	
+	@Test
+	def test_IM_extend_datatype_conflict() {
+		var fbModel = FunctionblockFactory.eINSTANCE.createFunctionblockModel()
+		fbModel.functionblock = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		fbModel.functionblock.status = FunctionblockFactory.eINSTANCE.createStatus()
+		fbModel.name = "FB"
+		
+		var prop = DatatypeFactory.eINSTANCE.createProperty()
+		prop.name = "prop1"
+		var strType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType()
+		strType.setType(PrimitiveType.STRING)
+		prop.type = strType
+	
+		fbModel.functionblock.status.properties.add(prop)
+		
+		var extendedFb = FunctionblockFactory.eINSTANCE.createFunctionBlock()
+		extendedFb.status = FunctionblockFactory.eINSTANCE.createStatus()
+		var extProperty = DatatypeFactory.eINSTANCE.createProperty()
+		extProperty.name = "prop1"
+		var intType = DatatypeFactory.eINSTANCE.createPrimitivePropertyType();
+		intType.setType(PrimitiveType.INT);
+		extProperty.type = intType	
+		extendedFb.status.properties.add(extProperty)
+		
+		var fbModelExtended = FunctionblockFactory.eINSTANCE.createFunctionblockModel()
+		fbModelExtended.functionblock = extendedFb
+		fbModelExtended.superType = fbModel
+		fbModelExtended.name = "FBextended"
+		
+		tester.validator().checkStatusOverriddenProperties(fbModelExtended)
+		tester.diagnose().assertErrorContains(SystemMessage.ERROR_INCOMPATIBLE_TYPE);
+	}
+}

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
@@ -72,7 +72,7 @@ Fault:
 ;
  
 Operation :
-	 (presence = Presence)? (breakable ?= 'breakable')? name=ID '(' (params += Param (',' params+=Param)*)?')' ('returns'  returnType = ReturnType)? (description=STRING)?
+	 (extension ?= 'extension')? (presence = Presence)? (breakable ?= 'breakable')? name=ID '(' (params += Param (',' params+=Param)*)?')' ('returns'  returnType = ReturnType)? (description=STRING)?
 ;
 
 ReturnType :

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
@@ -83,8 +83,8 @@ class FunctionblockFormatter extends AbstractDeclarativeFormatter {
 		c.setNoSpace().after(f.propertyAccess.commaKeyword_6_3_0)
 		
 		//Operation parameters.
-		c.setNoSpace().before(f.operationAccess.commaKeyword_4_1_0)
-		c.setLinewrap(1).after(f.operationAccess.commaKeyword_4_1_0)
+		c.setNoSpace().before(f.operationAccess.commaKeyword_5_1_0)
+		c.setLinewrap(1).after(f.operationAccess.commaKeyword_5_1_0)
 		
 		//Property description
 		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_8)

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/formatting/FunctionblockFormatter.xtend
@@ -79,15 +79,15 @@ class FunctionblockFormatter extends AbstractDeclarativeFormatter {
 		c.setLinewrap(1).after(f.operationAccess.group)
 	
 		//Constraint parameters.
-		c.setNoSpace().before(f.propertyAccess.commaKeyword_5_3_0)
-		c.setNoSpace().after(f.propertyAccess.commaKeyword_5_3_0)
+		c.setNoSpace().before(f.propertyAccess.commaKeyword_6_3_0)
+		c.setNoSpace().after(f.propertyAccess.commaKeyword_6_3_0)
 		
 		//Operation parameters.
 		c.setNoSpace().before(f.operationAccess.commaKeyword_4_1_0)
 		c.setLinewrap(1).after(f.operationAccess.commaKeyword_4_1_0)
 		
 		//Property description
-		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_7)
-		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_7)
+		c.setNoLinewrap().before(f.propertyAccess.descriptionAssignment_8)
+		c.setLinewrap(2).after(f.propertyAccess.descriptionAssignment_8)
 	}
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -505,4 +505,5 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 			validateOverriddenOperations(parentFb.operations, baseFb.operations)
 		}
 	}
+
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.vorto.core.api.model.datatype.Constraint
 import org.eclipse.vorto.core.api.model.datatype.Entity
 import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
+import org.eclipse.vorto.core.api.model.datatype.Property
 import org.eclipse.vorto.core.api.model.datatype.Type
 import org.eclipse.vorto.core.api.model.functionblock.Configuration
 import org.eclipse.vorto.core.api.model.functionblock.Event
@@ -42,6 +43,18 @@ import org.eclipse.vorto.editor.datatype.validation.DatatypeSystemMessage
 import org.eclipse.vorto.editor.datatype.validation.PropertyConstraintMappingValidation
 import org.eclipse.vorto.editor.datatype.validation.ValidatorUtils
 import org.eclipse.xtext.validation.Check
+import org.eclipse.emf.common.util.EList
+import org.eclipse.vorto.core.api.model.datatype.PropertyType
+import org.eclipse.vorto.core.api.model.datatype.PrimitivePropertyType
+import org.eclipse.vorto.core.api.model.datatype.DictionaryPropertyType
+import org.eclipse.vorto.core.api.model.datatype.ObjectPropertyType
+import org.eclipse.vorto.core.api.model.datatype.DatatypePackage
+import org.eclipse.vorto.core.api.model.functionblock.Param
+import org.eclipse.emf.ecore.util.EcoreUtil
+import java.util.ArrayList
+import org.eclipse.vorto.core.api.model.datatype.ConstraintIntervalType
+import org.eclipse.vorto.core.api.model.datatype.BooleanPropertyAttribute
+import org.eclipse.vorto.core.api.model.datatype.EnumLiteralPropertyAttribute
 
 /**
  * Custom validation rules. 
@@ -227,7 +240,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 	
 	@Check
 	def checkCircularRefInSuperType(FunctionblockModel functionblock) {
-		if (functionblock.superType != null) {
+		if (functionblock.superType !== null) {
 			try {
 				if (ValidatorUtils.hasCircularReference(functionblock, functionblock.superType, FbValidatorUtils.modelToChildrenSupplierFunction)) {
 					error(DatatypeSystemMessage.ERROR_SUPERTYPE_CIRCULAR_REF, functionblock, FunctionblockPackage.Literals.FUNCTIONBLOCK_MODEL__SUPER_TYPE);
@@ -241,7 +254,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 	@Check
 	def checkRefParamIsImported(RefParam refParam) {
 		val topParent = ValidatorUtils.getParentOfType(refParam, FunctionblockModel) as FunctionblockModel
-		if (topParent != null && !ValidatorUtils.isTypeInReferences(refParam.type, topParent.references)) {
+		if (topParent !== null && !ValidatorUtils.isTypeInReferences(refParam.type, topParent.references)) {
 			error(SystemMessage.ERROR_REF_PARAM_NOT_IMPORTED, refParam, FunctionblockPackage.Literals.REF_PARAM__TYPE);
 		}
 	}
@@ -249,7 +262,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 	@Check
 	def checkReturnTypeIsImported(ReturnObjectType returnType) {
 		val topParent = ValidatorUtils.getParentOfType(returnType, FunctionblockModel) as FunctionblockModel
-		if (topParent != null && !ValidatorUtils.isTypeInReferences(returnType.returnType, topParent.references)) {
+		if (topParent !== null && !ValidatorUtils.isTypeInReferences(returnType.returnType, topParent.references)) {
 			error(SystemMessage.ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED, returnType, FunctionblockPackage.Literals.RETURN_OBJECT_TYPE__RETURN_TYPE);
 		}
 	}
@@ -262,4 +275,234 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 		this.helper
 	}
 
+	def String getPropertyName(PropertyType propertyType) {
+		if (propertyType instanceof PrimitivePropertyType) {
+			return propertyType.type.literal
+		} else if (propertyType instanceof DictionaryPropertyType) {
+			return "dict" + getPropertyName(propertyType.keyType) + getPropertyName(propertyType.valueType)
+		} else if (propertyType instanceof ObjectPropertyType) {
+			return propertyType.getType().name
+		}
+	}
+
+	def validateOvewrittenPropertyAttr(Property baseProperty, Property extProperty) {
+		for (propAttr : extProperty.propertyAttributes) {
+			for (basePropAttr : baseProperty.propertyAttributes) {
+				if (propAttr instanceof BooleanPropertyAttribute && basePropAttr instanceof BooleanPropertyAttribute) {
+					if ((propAttr as BooleanPropertyAttribute).getType().equals(
+						(basePropAttr as BooleanPropertyAttribute).getType())) {
+						error(SystemMessage.ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE, extProperty,
+							DatatypePackage.Literals.PROPERTY__PROPERTY_ATTRIBUTES)
+					}
+				} else if (propAttr instanceof EnumLiteralPropertyAttribute &&
+					basePropAttr instanceof EnumLiteralPropertyAttribute) {
+					if ((propAttr as EnumLiteralPropertyAttribute).getType().getName().equals(
+						(basePropAttr as EnumLiteralPropertyAttribute).getType().getName())) {
+						error(SystemMessage.ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE, extProperty,
+							DatatypePackage.Literals.PROPERTY__PROPERTY_ATTRIBUTES)
+					}
+				}
+			}
+		}
+	}
+
+	def ArrayList<String> validateOverriddenConstraints(Property baseProperty, Property extProperty) {
+		var validatedConstraints = new ArrayList<String>()
+		if (baseProperty.constraintRule === null) {
+			return validatedConstraints
+		}
+		var constraintsMap = baseProperty.constraintRule.constraints.toMap[type].mapValues[it]
+		for (costraint : extProperty.constraintRule.constraints) {
+			var constraintId = baseProperty.name + costraint.type.getName
+			if (!validatedConstraints.contains(constraintId)) {
+				validatedConstraints.add(constraintId)
+				var baseConstraint = constraintsMap.get(costraint.type)
+				if (baseConstraint !== null) {
+					if (costraint.type == ConstraintIntervalType.MIN) {
+						if (Double.parseDouble(costraint.constraintValues) <
+							Double.parseDouble(baseConstraint.constraintValues)) {
+							error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_MIN_TOO_SMALL, costraint,
+								DatatypePackage.Literals.CONSTRAINT__TYPE)
+						}
+					} else if (costraint.type == ConstraintIntervalType.MAX) {
+						if (Double.parseDouble(costraint.constraintValues) >
+							Double.parseDouble(baseConstraint.constraintValues)) {
+							error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_MAX_TOO_BIG, costraint,
+								DatatypePackage.Literals.CONSTRAINT__TYPE)
+						}
+					} else if (costraint.type == ConstraintIntervalType.STRLEN) {
+						if (Double.parseDouble(costraint.constraintValues) >
+							Double.parseDouble(baseConstraint.constraintValues)) {
+							error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_STRLEN, costraint,
+								DatatypePackage.Literals.CONSTRAINT__TYPE)
+						}
+					} else if (costraint.type == ConstraintIntervalType.NULLABLE) {
+						if (costraint.constraintValues.equals("true") &&
+							baseConstraint.constraintValues.equals("false")) {
+							error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_NULLABLE, costraint,
+								DatatypePackage.Literals.CONSTRAINT__TYPE)
+						} else {
+							error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_ALREADY_DEFINED, costraint,
+								DatatypePackage.Literals.CONSTRAINT__TYPE)
+						}
+					} else {
+						error(SystemMessage.ERROR_OVERWRITTEN_CONSTRAINT_ALREADY_DEFINED, costraint,
+							DatatypePackage.Literals.CONSTRAINT__TYPE)
+					}
+				}
+			}
+		}
+		return validatedConstraints
+	}
+
+	def ArrayList<String> validateOverriddenProperties(EList<Property> properties, EList<Property> extProperties,
+		ArrayList<String> validatedConstraints) {
+		var propertiesMap = properties.toMap[name].mapValues[it]
+
+		var equalHelper = new EcoreUtil.EqualityHelper()
+		for (property : extProperties) {
+			var baseProperty = propertiesMap.get(property.name)
+			if (baseProperty !== null) {
+				if (!equalHelper.equals(property.presence, baseProperty.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, property,
+						DatatypePackage.Literals.PROPERTY__PRESENCE)
+				}
+				if (property.multiplicity != baseProperty.multiplicity) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_MULTIPLICITY, property,
+						DatatypePackage.Literals.PROPERTY__MULTIPLICITY)
+				}
+				if (!equalHelper.equals(property.type, baseProperty.type)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_TYPE, property, DatatypePackage.Literals.PROPERTY__TYPE)
+				}
+				validateOvewrittenPropertyAttr(baseProperty, property)
+				validatedConstraints.addAll(validateOverriddenConstraints(baseProperty, property))
+			}
+		}
+		return validatedConstraints
+	}
+
+	def equalsParamList(List<Param> list1, List<Param> list2) {
+		var size = list1.size();
+		if (size != list2.size()) {
+			return false;
+		}
+		var equalHelper = new EcoreUtil.EqualityHelper();
+		for (var i = 0; i < size; i++) {
+			if (!equalHelper.equals(list1.get(i), list2.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	def validateOverriddenOperations(EList<Operation> operations, EList<Operation> extOperations) {
+		var operationsMap = operations.toMap[name].mapValues[it]
+		var equalHelper = new EcoreUtil.EqualityHelper()
+
+		for (operation : extOperations) {
+			var baseOperation = operationsMap.get(operation.name)
+			if (baseOperation !== null) {
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (operation.breakable != baseOperation.breakable) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_BREAKABLE, operation,
+						FunctionblockPackage.Literals.OPERATION__BREAKABLE)
+				}
+				if (!equalHelper.equals(operation.presence, baseOperation.presence)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PRESENCE, operation,
+						FunctionblockPackage.Literals.OPERATION__PRESENCE)
+				}
+				if (!equalsParamList(operation.params, baseOperation.params)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_PARMS, operation,
+						FunctionblockPackage.Literals.OPERATION__PARAMS)
+				}
+				if (!equalHelper.equals(operation.returnType, baseOperation.returnType)) {
+					error(SystemMessage.ERROR_INCOMPATIBLE_RETURN_TYPE, operation,
+						FunctionblockPackage.Literals.OPERATION__RETURN_TYPE)
+				}
+			}
+		}
+	}
+
+	def validateOverriddenEvents(EList<Event> events, EList<Event> extEvents) {
+		var validatedConstraints = new ArrayList<String>()
+		var eventsMap = events.toMap[name].mapValues[it]
+		for (event : extEvents) {
+			var baseEvent = eventsMap.get(event.name)
+			if (baseEvent !== null) {
+				validatedConstraints = validateOverriddenProperties(baseEvent.properties, event.properties,
+					validatedConstraints)
+			}
+		}
+	}
+
+	def getParentFunctionBlocks(FunctionblockModel baseFunctionblockModel) {
+		var functionBlocks = new ArrayList<FunctionBlock>()
+		var lastFunctionblockModel = baseFunctionblockModel
+		while (lastFunctionblockModel.superType !== null) {
+			if (lastFunctionblockModel === lastFunctionblockModel.superType) {
+				return functionBlocks
+			}
+			lastFunctionblockModel = lastFunctionblockModel.superType
+			functionBlocks.add(lastFunctionblockModel.functionblock)
+		}
+		return functionBlocks
+	}
+
+	@Check
+	def checkConfigurationOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var validatedConstraints = new ArrayList<String>()
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.configuration !== null && baseFb.configuration !== null) {
+				validateOverriddenProperties(parentFb.configuration.properties, baseFb.configuration.properties,
+					validatedConstraints)
+			}
+		}
+	}
+
+	@Check
+	def checkStatusOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var validatedConstraints = new ArrayList<String>()
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.status !== null && baseFb.status !== null) {
+				validateOverriddenProperties(parentFb.status.properties, baseFb.status.properties, validatedConstraints)
+			}
+		}
+	}
+
+	@Check
+	def checkFaultOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var validatedConstraints = new ArrayList<String>()
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			if (parentFb.fault !== null && baseFb.fault !== null) {
+				validateOverriddenProperties(parentFb.fault.properties, baseFb.fault.properties, validatedConstraints)
+			}
+		}
+	}
+
+	@Check
+	def checkEventsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			validateOverriddenEvents(parentFb.events, baseFb.events)
+		}
+	}
+
+	@Check
+	def checkOperationsOverriddenProperties(FunctionblockModel baseFunctionblockModel) {
+		var baseFb = baseFunctionblockModel.functionblock;
+		var parentFunctionBlocks = getParentFunctionBlocks(baseFunctionblockModel)
+		for (parentFb : parentFunctionBlocks) {
+			validateOverriddenOperations(parentFb.operations, baseFb.operations)
+		}
+	}
 }

--- a/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
+++ b/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/SystemMessage.xtend
@@ -35,5 +35,19 @@ class SystemMessage {
 	public static final String ERROR_REF_PARAM_NOT_IMPORTED = "Reference parameter has not yet been imported.";
 	
 	public static final String ERROR_OBJECT_RETURN_TYPE_NOT_IMPORTED = "Return type has not yet been imported.";
+
+	public static final String ERROR_INCOMPATIBLE_TYPE = 'The property type is incompatible to base type.'
+	public static final String ERROR_INCOMPATIBLE_PRESENCE = 'The presence is incompatible to presence of the base type.'
+	public static final String ERROR_INCOMPATIBLE_MULTIPLICITY = 'The multiplicity is incompatible to multiplicity of the base type.'
+	public static final String ERROR_INCOMPATIBLE_BREAKABLE = 'The breakable definition is incompatible to base operation.'
+	public static final String ERROR_INCOMPATIBLE_PARMS = 'The parameters are incompatible to base operation parameters.'
+	public static final String ERROR_INCOMPATIBLE_RETURN_TYPE = 'The return type is incompatible to base type.'
+	
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_MIN_TOO_SMALL = 'The given MIN constraint needs to be bigger or equal as the base MIN value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_MAX_TOO_BIG = 'The given MAX constraint needs to be smaller or equal as the base MAX value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_NULLABLE = 'If the constraint NULLABLE of the base type is false than it can not changed.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_STRLEN = 'The given STRLEN constraint needs to be smaller or equal as the base STRLEN value.'
+	public static final String ERROR_OVERWRITTEN_CONSTRAINT_ALREADY_DEFINED = 'The constraint is already defined in the base property.'
+	public static final String ERROR_OVERWRITTEN_PROPERTY_ATTRIBUTE_TYPE = 'Property attributes can not be overwritten.'
 	
 }

--- a/framework/org.eclipse.vorto.core/model/Datatype.ecore
+++ b/framework/org.eclipse.vorto.core/model/Datatype.ecore
@@ -19,6 +19,7 @@
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="propertyAttributes" upperBound="-1"
         eType="#//PropertyAttribute" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="extension" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="PrimitivePropertyType" eSuperTypes="#//PropertyType">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="#//PrimitiveType"/>

--- a/framework/org.eclipse.vorto.core/model/Functionblock.ecore
+++ b/framework/org.eclipse.vorto.core/model/Functionblock.ecore
@@ -45,6 +45,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="breakable" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="presence" eType="ecore:EClass Datatype.ecore#//Presence"
         containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="extension" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ReturnType">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiplicity" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>


### PR DESCRIPTION
I have implemented that if a value is overwritten not all property attributes and constraints have to be written again. They are inherited from the parent FB. I am not sure if this would create more confusion and complications about the behaviour. The editor shows an error message if this rule is violated. Unit test currently not complete.

I am open for a discussion. How do you feel about this @aedelmann? Yes/No would be fine. The other option would be to require all attributes and constraints to be written again. I am a bit undecided here.

**Here some examples:**
```
mandatory xValue as float with { readable: true} 
```
Can be overwritten with:
```
mandatory xValue as float <MAX 100>
```
Evaluated as:
```
mandatory xValue as float with { readable: true} <MAX 100>
```
**Second example:**
```
mandatory xValue as float <MIN 10, MAX 100>
```
Can be overwritten with:
```
mandatory xValue as float <MAX 99>
```
Evaluated as:
```
mandatory xValue as float <MIN 10, MAX 99>
```
**Third example:**
```
mandatory xValue as float with { readable: true} 
```
Can be overwritten with:
```
mandatory xValue as float with { writable: true} 
```
Evaluated as:
```
mandatory xValue as float with { readable: true, writable: true}
```