### PR TITLE
Allow underscore in namespace

### DIFF
--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/validation/FunctionblockValidator.xtend
@@ -162,7 +162,7 @@ class FunctionblockValidator extends AbstractFunctionblockValidator {
 
 	@Check
 	def checkNamespacePattern(FunctionblockModel functionblock) {
-		if (!functionblock.namespace.matches("([a-z0-9]*\\.)*[a-z0-9]*")) {
+		if (!functionblock.namespace.matches("([a-z0-9_]*\\.)*[a-z0-9_]*")) {
 			error(SystemMessage.ERROR_NAMESPACE_PATTERN, functionblock,
 				ModelPackage.Literals.MODEL__VERSION)
 		}


### PR DESCRIPTION
Adds to the validation that underscores are also allowed in FBs. If the domain contains a hyphen a underscore should be used just like in Java.