### PR TITLE
Fixes #956 - Allow FB section names as property name

### DIFF
--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ide/META-INF/MANIFEST.MF
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ide/META-INF/MANIFEST.MF
@@ -7,8 +7,10 @@ Bundle-SymbolicName: org.eclipse.vorto.editor.datatype.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.vorto.editor.datatype,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide
+ org.eclipse.xtext.xbase.ide,
+ org.eclipse.vorto.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.vorto.editor.datatype.ide.contentassist.an
- tlr,org.eclipse.vorto.editor.datatype.ide.contentassist.antlr.internal
+Export-Package: org.eclipse.vorto.editor.datatype.ide.contentassist.antlr,
+ org.eclipse.vorto.editor.datatype.ide.contentassist.antlr.internal,
+ org.eclipse.vorto.editor.datatype.ide.syntaxcoloring
 Import-Package: org.eclipse.vorto.editor.datatype.services

--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ide/src/org/eclipse/vorto/editor/datatype/ide/syntaxcoloring/PropertyNameSemanticHighlightingCalculator.xtend
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ide/src/org/eclipse/vorto/editor/datatype/ide/syntaxcoloring/PropertyNameSemanticHighlightingCalculator.xtend
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ */
+package org.eclipse.vorto.editor.datatype.ide.syntaxcoloring
+
+import javax.inject.Inject
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.ide.editor.syntaxcoloring.DefaultSemanticHighlightingCalculator
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor
+import org.eclipse.xtext.util.CancelIndicator
+
+import org.eclipse.vorto.core.api.model.datatype.Property
+import org.eclipse.vorto.core.api.model.datatype.DatatypePackage
+import org.eclipse.vorto.editor.datatype.services.DatatypeGrammarAccess
+import org.eclipse.xtext.ide.editor.syntaxcoloring.HighlightingStyles
+
+class PropertyNameSemanticHighlightingCalculator extends DefaultSemanticHighlightingCalculator {
+	@Inject package DatatypeGrammarAccess grammar
+
+	override protected boolean highlightElement(EObject object, IHighlightedPositionAcceptor acceptor,
+		CancelIndicator cancelIndicator) {
+		switch (object) {
+			Property: {
+				highlightFeature(acceptor, object, DatatypePackage.eINSTANCE.property_Name, HighlightingStyles.DEFAULT_ID)
+				return true
+			}
+			default: false
+		}
+	}
+}

--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ui/src/org/eclipse/vorto/editor/datatype/ui/DatatypeUiModule.xtend
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype.ui/src/org/eclipse/vorto/editor/datatype/ui/DatatypeUiModule.xtend
@@ -1,5 +1,5 @@
 /** 
- * Copyright (c) 2015-2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2015-2018 Bosch Software Innovations GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
@@ -17,6 +17,8 @@ package
 org.eclipse.vorto.editor.datatype.ui
 
 import org.eclipse.ui.plugin.AbstractUIPlugin
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.vorto.editor.datatype.ide.syntaxcoloring.PropertyNameSemanticHighlightingCalculator
 
 /** 
  * Use this class to register components to be used within the IDE.
@@ -24,5 +26,8 @@ import org.eclipse.ui.plugin.AbstractUIPlugin
 class DatatypeUiModule extends org.eclipse.vorto.editor.datatype.ui.AbstractDatatypeUiModule {
 	new(AbstractUIPlugin plugin) {
 		super(plugin)
+	}
+	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator () {
+		PropertyNameSemanticHighlightingCalculator
 	}
 }

--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/Datatype.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2014-2018 Bosch Software Innovations GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
@@ -63,7 +63,7 @@ EnumLiteral:
 ;
 
 Property:
-	(extension ?= 'extension')? (presence = Presence)? (multiplicity ?= 'multiple')? name = ID 'as' type = PropertyType
+	(extension ?= 'extension')? (presence = Presence)? (multiplicity ?= 'multiple')? name = ValidID 'as' type = PropertyType
 	('with' '{' propertyAttributes+=PropertyAttribute (',' propertyAttributes+=PropertyAttribute)* '}')?
 	('<' constraintRule = ConstraintRule '>')?
 	(description=STRING)?
@@ -140,6 +140,10 @@ BOOLEAN:
 ;
 
 CATEGORY: ID ('/' ID)*;
+
+ValidID: ID | KEYWORD;
+
+KEYWORD: 'status'|'events'|'operations'|'configuration'|'fault';
 
 terminal SIGNEDINT :
 	'-'INT

--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock.ui/META-INF/MANIFEST.MF
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.xtext.ui,
  org.eclipse.vorto.editor.functionblock.ide,
  org.eclipse.vorto.core,
  org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.vorto.editor.datatype.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.vorto.editor.functionblock.ui,org.eclipse.
  vorto.editor.functionblock.ui.contentassist,org.eclipse.vorto.editor.

--- a/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock.ui/src/org/eclipse/vorto/editor/functionblock/ui/FunctionblockUiModule.xtend
+++ b/toolset/eclipse/bundles/org.eclipse.vorto.editor.functionblock.ui/src/org/eclipse/vorto/editor/functionblock/ui/FunctionblockUiModule.xtend
@@ -17,6 +17,8 @@ package
 org.eclipse.vorto.editor.functionblock.ui
 
 import org.eclipse.ui.plugin.AbstractUIPlugin
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.vorto.editor.datatype.ide.syntaxcoloring.PropertyNameSemanticHighlightingCalculator
 
 /** 
  * Use this class to register components to be used within the IDE.
@@ -24,5 +26,8 @@ import org.eclipse.ui.plugin.AbstractUIPlugin
 class FunctionblockUiModule extends org.eclipse.vorto.editor.functionblock.ui.AbstractFunctionblockUiModule {
 	new(AbstractUIPlugin plugin) {
 		super(plugin)
+	}
+	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator () {
+		PropertyNameSemanticHighlightingCalculator
 	}
 }


### PR DESCRIPTION
Now `status`, `events`, `operations`, `configuration` and `fault` are allowed as property name. 
Lets discuss which other keywords make sense to add in a new issue. If I have time I like to create a list of all available keywords.