### PR TITLE
Minor refactoring and add checking of imported flag on unit test.

### DIFF
--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/IModelRepository.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/IModelRepository.java
@@ -119,7 +119,7 @@ public interface IModelRepository {
      * @param value the value of the imported property
      * @return
      */
-    ModelId updateImported(ModelId modelId, boolean value);
+    ModelInfo updateImported(ModelInfo modelInfo);
 
     /**
      * adds the given file content to the model

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/JcrModelRepository.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/JcrModelRepository.java
@@ -428,8 +428,9 @@ public class JcrModelRepository implements IModelRepository {
 		return updateProperty(modelId, node -> node.setProperty("vorto:state", state));
 	}
 	
-	public ModelId updateImported(ModelId modelId, boolean value) {
-		return updateProperty(modelId, node -> node.setProperty("vorto:imported", value));
+	public ModelInfo updateImported(ModelInfo model) {
+		updateProperty(model.getId(), node -> node.setProperty("vorto:imported", model.getImported()));
+		return model;
 	}
 	
 	private ModelId updateProperty(ModelId modelId, NodeConsumer nodeConsumer) {

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/importer/AbstractModelImporter.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/importer/AbstractModelImporter.java
@@ -208,10 +208,12 @@ public abstract class AbstractModelImporter implements IModelImporter {
 		dm.getSorted().stream().forEach(resource -> {
 			try {
 				ModelInfo importedModel = this.modelRepository.save(resource.getId(), ((ModelResource)resource).toDSL(), createFileName(resource), user);
-				savedModels.add(importedModel);
 				
 				// Add a marker that this model was imported
-				modelRepository.updateImported(importedModel.getId(), true);
+				importedModel.setImported(true);
+				modelRepository.updateImported(importedModel);
+				
+				savedModels.add(importedModel);
 				
 				postProcessImportedModel(importedModel, new FileContent(extractedFile.getFileName(),extractedFile.getContent()));
 			} catch (Exception e) {

--- a/repository/repository-server/src/test/java/org/eclipse/vorto/repository/importer/ModelImporterTest.java
+++ b/repository/repository-server/src/test/java/org/eclipse/vorto/repository/importer/ModelImporterTest.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.vorto.repository.AbstractIntegrationTest;
@@ -162,8 +163,9 @@ public class ModelImporterTest extends AbstractIntegrationTest {
 
 		when(userRepository.findAll()).thenReturn(recipients);
 
-		this.importer.doImport(uploadResult.getHandleId(), UserContext.user(user1.getUsername()));
-
+		List<ModelInfo> modelInfos = importer.doImport(uploadResult.getHandleId(), UserContext.user(user1.getUsername()));
+		modelInfos.forEach(resource -> assertEquals(true, resource.getImported()));
+		
 		Thread.sleep(1000);
 		assertEquals(1, modelRepository.search("*").size());
 	}


### PR DESCRIPTION
This refactoring was due to the fact that the output of doImport of AbstractModelImporter doesn't actually set the imported flag to true even if in the database, it already is. This fixes it.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>