### PR TITLE
- Use the author's username in the metadata of the model instead of t…

### DIFF
--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/comment/impl/DefaultCommentService.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/comment/impl/DefaultCommentService.java
@@ -45,7 +45,7 @@ public class DefaultCommentService implements ICommentService{
 		final ModelId id = ModelId.fromPrettyFormat(comment.getModelId());
 		
 		if (modelRepository.getById(id) != null){
-			comment.setAuthor(UserContext.user(comment.getAuthor()).getHashedUsername());
+			comment.setAuthor(comment.getAuthor());
 			comment.setModelId(id.getPrettyFormat());
 			comment.setDate(new Date());
 			commentRepository.save(comment);

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/IUserContext.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/IUserContext.java
@@ -3,6 +3,8 @@ package org.eclipse.vorto.repository.core;
 public interface IUserContext {
 	
 	String getUsername();
+	
+	//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
 	String getHashedUsername();
 	
 	boolean isAnonymous();

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/JcrModelRepository.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/JcrModelRepository.java
@@ -245,14 +245,14 @@ public class JcrModelRepository implements IModelRepository {
 				fileNode.addMixin("vorto:meta");
 				fileNode.addMixin("mix:referenceable");
 				fileNode.addMixin("mix:lastModified");
-				fileNode.setProperty("vorto:author", userContext.getHashedUsername());
+				fileNode.setProperty("vorto:author", userContext.getUsername());
 				Node contentNode = fileNode.addNode("jcr:content", "nt:resource");
 				Binary binary = session.getValueFactory().createBinary(new ByteArrayInputStream(content));
 				contentNode.setProperty("jcr:data", binary);
 			} else { // node already exists.
 				Node fileNode = nodeIt.nextNode();
 				fileNode.addMixin("mix:lastModified");
-				fileNode.setProperty("vorto:author", userContext.getHashedUsername());
+				fileNode.setProperty("vorto:author", userContext.getUsername());
 				Node contentNode = fileNode.getNode("jcr:content");
 				Binary binary = session.getValueFactory().createBinary(new ByteArrayInputStream(content));
 				contentNode.setProperty("jcr:data", binary);

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/UserContext.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/UserContext.java
@@ -23,6 +23,7 @@ public class UserContext implements IUserContext {
 		return username;
 	}
 	
+	//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
 	public String getHashedUsername() {
 		return getHash(username);
 	}

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/validation/DuplicateModelValidation.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/core/impl/validation/DuplicateModelValidation.java
@@ -59,6 +59,7 @@ public class DuplicateModelValidation implements IModelValidator {
 		assert(context != null);
 		assert(context.getUserContext() != null);
 		
-		return model.getAuthor().equalsIgnoreCase(context.getUserContext().getHashedUsername());
+		// TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+		return model.getAuthor().equalsIgnoreCase(context.getUserContext().getHashedUsername()) || model.getAuthor().equalsIgnoreCase(context.getUserContext().getUsername());
 	}
 }

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/importer/AbstractModelImporter.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/importer/AbstractModelImporter.java
@@ -130,7 +130,8 @@ public abstract class AbstractModelImporter implements IModelImporter {
 					report.setMessage(ValidationReport.ERROR_MODEL_ALREADY_RELEASED);
 					report.setValid(false);
 				} else {
-					if (isAdmin(user) || m.getAuthor().equals(user.getHashedUsername())) {
+					//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+					if (isAdmin(user) || m.getAuthor().equals(user.getHashedUsername()) || m.getAuthor().equals(user.getUsername())) {
 						report.setMessage(ValidationReport.WARNING_MODEL_ALREADY_EXISTS);
 						report.setValid(true);
 					} else {

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/core/ModelDtoFactory.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/core/ModelDtoFactory.java
@@ -86,10 +86,6 @@ public class ModelDtoFactory {
 	public static ModelInfo createDto(ModelInfo resource, IUserContext userContext) {
 		ModelInfo dto = new ModelInfo(createDto(resource.getId()), ModelType.valueOf(resource.getType().name()));
 		
-		if (userContext.getHashedUsername().equals(resource.getAuthor())) {
-			dto.setAuthor(userContext.getUsername());
-		}
-		
 		dto.setCreationDate(resource.getCreationDate());
 		dto.setDescription(resource.getDescription());
 		dto.setDisplayName(resource.getDisplayName());
@@ -101,11 +97,13 @@ public class ModelDtoFactory {
 		dto.setFileName(resource.getFileName());
 		dto.setModificationDate(resource.getModificationDate());
 		dto.setImported(resource.getImported());
+		dto.setAuthor(resource.getAuthor());
 		
 		return dto;
 	}
 	
 	public static Comment createDto(Comment comment, IUserContext userContext) {
+		//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
 		if (userContext.getHashedUsername().equals(comment.getAuthor())) {
 			comment.setAuthor(userContext.getUsername());
 		}

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/core/ModelRepositoryController.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/core/ModelRepositoryController.java
@@ -182,8 +182,12 @@ public class ModelRepositoryController extends AbstractRepositoryController  {
 
 	@RequestMapping(value = { "/mine/download" }, method = RequestMethod.GET)
 	public void getUserModels(Principal user, final HttpServletResponse response) {
+		//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
 		List<ModelInfo> userModels = this.modelRepository
 				.search("author:" + UserContext.user(user.getName()).getHashedUsername());
+		
+		userModels.addAll(this.modelRepository.search("author:" + UserContext.user(user.getName()).getUsername()));
+		// TODO: end
 
 		logger.info("Exporting information models for " + user.getName() + " results: " + userModels.size());
 

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/security/HasPermissionEvaluator.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/security/HasPermissionEvaluator.java
@@ -44,15 +44,20 @@ public class HasPermissionEvaluator implements PermissionEvaluator {
 			ModelInfo modelInfo = this.repository.getById((ModelId) targetDomainObject);
 			if (modelInfo != null) {
 				if ("model:delete".equalsIgnoreCase((String)permission)) {
-					return modelInfo.getAuthor().equalsIgnoreCase(UserContext.user(callerId).getHashedUsername());
+					//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+					return modelInfo.getAuthor().equalsIgnoreCase(UserContext.user(callerId).getHashedUsername()) ||
+						   modelInfo.getAuthor().equalsIgnoreCase(UserContext.user(callerId).getUsername());
 				} else if ("model:get".equalsIgnoreCase((String)permission)) {
 					IUserContext user = UserContext.user(authentication.getName());
 					return modelInfo.getState().equals(SimpleWorkflowModel.STATE_RELEASED.getName()) || 
 						   modelInfo.getState().equals(SimpleWorkflowModel.STATE_DEPRECATED.getName()) ||
-						   modelInfo.getAuthor().equals(user.getHashedUsername());
+						   //TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+						   modelInfo.getAuthor().equals(user.getHashedUsername()) || 
+								   modelInfo.getAuthor().equals(user.getUsername());
 				} else if ("model:owner".equalsIgnoreCase((String)permission)) {
 					IUserContext user = UserContext.user(authentication.getName());
-					return modelInfo.getAuthor().equals(user.getHashedUsername());
+					//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+					return modelInfo.getAuthor().equals(user.getHashedUsername()) || modelInfo.getAuthor().equals(user.getUsername());
 				}
 				
 			}

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/workflow/WorkflowController.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/web/workflow/WorkflowController.java
@@ -65,7 +65,7 @@ public class WorkflowController {
     				produces = "application/json")
     public ModelInfo claimModel(@ApiParam(value = "modelId", required = true) @PathVariable String modelId) {
     	ModelInfo model = this.modelRepository.getById(ModelId.fromPrettyFormat(modelId));
-    	model.setAuthor(UserContext.user(SecurityContextHolder.getContext().getAuthentication().getName()).getHashedUsername());
+    	model.setAuthor(UserContext.user(SecurityContextHolder.getContext().getAuthentication().getName()).getUsername());
     	return this.modelRepository.updateMeta(model);
 	
     }

--- a/repository/repository-server/src/main/java/org/eclipse/vorto/repository/workflow/impl/conditions/IsOwnerCondition.java
+++ b/repository/repository-server/src/main/java/org/eclipse/vorto/repository/workflow/impl/conditions/IsOwnerCondition.java
@@ -22,7 +22,8 @@ public class IsOwnerCondition implements IWorkflowCondition {
 
 	@Override
 	public boolean passesCondition(ModelInfo model, IUserContext user) {
-		return model.getAuthor().equals(user.getHashedUsername());
+		//TODO : Checking for hashedUsername is legacy and needs to be removed once full migration has taken place
+		return model.getAuthor().equals(user.getHashedUsername()) || model.getAuthor().equals(user.getUsername());
 	}
 
 }

--- a/repository/repository-server/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
+++ b/repository/repository-server/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
@@ -42,8 +42,8 @@ public class UserAccountServiceTest extends AbstractIntegrationTest  {
 		
 		when(userRepository.findByUsername("alex")).thenReturn(User.create("alex"));
 
-		assertEquals(2,this.modelRepository.search("author:" + alex.getHashedUsername()).size());
+		assertEquals(2,this.modelRepository.search("author:" + alex.getUsername()).size());
 		accountService.delete("alex");		
-		assertEquals(2,this.modelRepository.search("author:" + alex.getHashedUsername()).size());
+		assertEquals(2,this.modelRepository.search("author:" + alex.getUsername()).size());
 	}
 }

--- a/repository/repository-server/src/test/java/org/eclipse/vorto/repository/core/ModelRepositoryTest.java
+++ b/repository/repository-server/src/test/java/org/eclipse/vorto/repository/core/ModelRepositoryTest.java
@@ -191,7 +191,7 @@ public class ModelRepositoryTest extends AbstractIntegrationTest {
 		importModel("ColorLightIM.infomodel", UserContext.user("admin"));
 		importModel("HueLightStrips.infomodel", UserContext.user("admin"));
 		
-		assertEquals(2, modelRepository.search("author:" + alex.getHashedUsername()).size());
+		assertEquals(2, modelRepository.search("author:" + alex.getUsername()).size());
 	}
 	
 	
@@ -235,8 +235,8 @@ public class ModelRepositoryTest extends AbstractIntegrationTest {
 		importModel("Colorlight.fbmodel", erle);
 		importModel("Switcher.fbmodel", admin);
 		
-		assertEquals(2, modelRepository.search("author:" + UserContext.user("erle").getHashedUsername()).size());
-		assertEquals(1, modelRepository.search("author:" + UserContext.user("admin").getHashedUsername()).size());
+		assertEquals(2, modelRepository.search("author:" + UserContext.user("erle").getUsername()).size());
+		assertEquals(1, modelRepository.search("author:" + UserContext.user("admin").getUsername()).size());
 	}
 
 }

--- a/repository/repository-web/src/main/resources/static/partials/details-template.html
+++ b/repository/repository-web/src/main/resources/static/partials/details-template.html
@@ -120,8 +120,13 @@
 											</dt>
 											<dd class="ng-binding">{{model.creationDate | date:'yyyy-MM-dd HH:mm'}}</dd>
 											<dt>Created By:</dt>
+											
+											<!-- 
 											<dd class="ng-binding" ng-show="model.author === user">You</dd>
 											<dd class="ng-binding" ng-hide="model.author === user">Other user</dd>
+											 -->
+											<dd class="ng-binding">{{ model.author }}</dd>
+											
 											<dt>References:</dt>
 											<dd>
 												<div ng-show="modelReferences.show">


### PR DESCRIPTION
…he hashed username

- Changed all the comparisons to hashed username to compare with hashed username
  or username. This is to accomodate a point in time where models are
  added but upgrade hasn't yet taken place.
- Added TODO on all parts of the code that are still comparing against
  hashed usernames for possible deletion in the future.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>