### PR TITLE
Fixes #1038 - Use ValidId for operation parameters

### DIFF
--- a/core-bundles/language/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
+++ b/core-bundles/language/org.eclipse.vorto.editor.functionblock/src/org/eclipse/vorto/editor/functionblock/Functionblock.xtext
@@ -92,15 +92,15 @@ ReturnPrimitiveType :
 ;
 
 DictonaryParam:
-	(multiplicity ?= 'multiple')? name = ID 'as' type = DictionaryPropertyType ('<' constraintRule = ConstraintRule '>')?  (description=STRING)?
+	(multiplicity ?= 'multiple')? name = ValidID 'as' type = DictionaryPropertyType ('<' constraintRule = ConstraintRule '>')?  (description=STRING)?
 ;
 
 PrimitiveParam:
-	(multiplicity ?= 'multiple')? name = ID 'as' type = PrimitiveType ('<' constraintRule = ConstraintRule '>')?  (description=STRING)?
+	(multiplicity ?= 'multiple')? name = ValidID 'as' type = PrimitiveType ('<' constraintRule = ConstraintRule '>')?  (description=STRING)?
 ;
 
 RefParam:
-	(multiplicity ?= 'multiple')? name = ID 'as' type = [datatype::Type|QualifiedName] (description=STRING)?
+	(multiplicity ?= 'multiple')? name = ValidID 'as' type = [datatype::Type|QualifiedName] (description=STRING)?
 ;
 
 Param:


### PR DESCRIPTION
Use the ValidId ParseRule (ID + keywords) for operation parameters (primitive, dict and ref).