### PR TITLE
Adds required modules to use the mapping engine on android

### DIFF
--- a/mapping-engine/Readme.md
+++ b/mapping-engine/Readme.md
@@ -1,32 +1,135 @@
 # Vorto Payload Mapping Engine
 
-The Payload Mapping Engine allows to map arbitrary device data to platform - specific data structure complying to Vorto Information Models.  
+The Payload Mapping Engine allows to map arbitrary device data to platform - specific data structure complying to Vorto Information Models. 
 
-Follow the following easy steps to get started: 
+## Getting started
 
-1. Login to Vorto Repository
+There are a couple steps you need to complete to successfully integrate the Vorto mapping engine into your project. They are outlined below just follow one after another and you will be good to go in no time.
+
+### Create a mapping
+
+1. Login to [the Vorto Repository](https://vorto.eclipse.org/)
 2. Select an existing Information Model or optionally create a new Information Model
-3. Choose 'Create Payload Mapping' and specify a new mapping key, e.g. myplatform
-4. Specify the mapping rules using (x)path expressions. You can test your mapping right away by selecting 'Test' and specify device test data.
-5. Save your mapping and click 'Download Mapping'. This will download the mapping specification as JSON.
-6. Add the following Maven dependency to your project:
+3. Choose 'Create Payload Mapping' and specify a new mapping key, e.g. myplatform 
 
-```
+5. Specify the mapping rules using (x)path expressions. You can test your mapping right away by selecting 'Test' and specify device test data.
+6. Save your mapping and click 'Download Mapping'. This will download the mapping specification as JSON.
+
+
+### Add Mapping Engine dependency
+
+To use the mapping engine you need to add the dependencies to your project. Depending on what features you want to use later you might not need all, but for now let’s add all of them.
+
+#### Maven
+```maven
 <dependency>
    <groupId>org.eclipse.vorto</groupId>
    <artifactId>mapping-engine-all</artifactId>
    <version>LATEST</version>
 </dependency>
-
+<dependency>
+   <groupId>org.eclipse.vorto</groupId>
+   <artifactId>mapping-core</artifactId>
+   <version>LATEST</version>
+</dependency>
+<dependency>
+   <groupId>org.eclipse.vorto</groupId>
+   <artifactId>mapping-converter-javascript</artifactId>
+   <version>LATEST</version>
+</dependency>
+```
+#### Gradle
+```gradle
+implementation('org.eclipse.vorto:mapping-core-android:+')
+implementation('org.eclipse.vorto:mapping-engine-android:+')
+implementation('org.eclipse.vorto:mapping-converter-javascript-android:+')
 ```
 
-7. Create the mapping engine with your downloaded mapping specification JSON:
-
-```
+### Use the mapping engine
+You are almost done, since you already have a specification and the dependencies you now only need to add a couple lines of code where ever you want to use the mapping engine
+```java
 MappingEngine engine = MappingEngine.create(mappingSpecJSON);
 
 InfomodelData mappedOutput = engine.map(DataInput.newInstance().fromObject(deviceData));
 
 ```
 
-Take a look at a [demo app](demo)
+If there are any open questions maybe the [demo app](demo) can help you if not feel free to just drop us a note.
+
+
+## Good to know
+
+### IDataMapper
+
+To allow a fine regulation of what the mapping engine should or should not do you can use the direct DataMapper Builder to add your own custom java functions
+
+```java
+IMappingSpecification specification = IMappingSpecification.newBuilder().fromInputStream(getAssets()
+                    .open("devices_TISensorTag_1.0.1-mappingspec_test.json"))
+                    .build();
+
+IDataMapper mapper = IDataMapper.newBuilder()
+                    .registerScriptEvalProvider(new JavascriptEvalProvider())
+                    .registerConverterFunction(StringFunctionFactory.createFunctions())
+                    .registerConditionFunction(DateFunctionFactory.createFunctions())
+                    .withSpecification(specification).build();
+                    
+InfomodelValue value = mapper.mapSource(obj);
+```
+
+### Custom Functions
+
+Writing all your conversions using Javascript is a little bit tedious, that’s why we offer the possibility to develop your own converter functions and register them on engine creation.
+
+To register them add your FunctionFactory on creation time like this:
+
+```java
+IDataMapper.newBuilder()
+	    .registerScriptEvalProvider(new JavascriptEvalProvider())
+            .registerConverterFunction(BinaryFunctionFactory.createFunctions())
+            .registerConverterFunction(DateFunctionFactory.createFunctions())
+            .registerConverterFunction(StringFunctionFactory.createFunctions())
+            .registerConverterFunction(TypeFunctionFactory.createFunctions())
+            .registerConditionFunction(BinaryFunctionFactory.createFunctions())
+            .registerConditionFunction(DateFunctionFactory.createFunctions())
+            .registerConditionFunction(StringFunctionFactory.createFunctions())
+            .registerConditionFunction(TypeFunctionFactory.createFunctions())
+            .withSpecification(specification);
+```
+To see how one would develop a FunctionFactory check out the packages: 
+* [mapping-converter-binary](./mapping-converter-binary)
+* [mapping-converter-date](./mapping-converter-date)
+* [mapping-converter-string](./mapping-converter-string)
+
+### convenience Class
+
+To provide working functions for each supported platform we offer a convenience class that adds most functions to the engine. Checkout out the sample code below on how to use it.
+
+```java
+IMappingSpecification specification = IMappingSpecification.newBuilder().fromInputStream(getAssets()
+                    .open("devices_TISensorTag_1.0.1-mappingspec_test.json"))
+                    .build();                    
+MappingEngine mappingEngine = new MappingEngine(specification);
+InfomodelValue value = mapper.mapSource(obj);
+```
+
+Add to maven project:
+```maven
+<dependency>
+   <groupId>org.eclipse.vorto</groupId>
+   <artifactId>mapping-engine-all</artifactId>
+   <version>LATEST</version>
+</dependency>
+```
+
+Add to Android Project:
+```gradle
+implementation('org.eclipse.vorto:mapping-engine-android')
+implementation('org.eclipse.vorto:mapping-core-android')
+
+```
+
+
+
+
+

--- a/mapping-engine/mapping-converter-javascript-android/pom.xml
+++ b/mapping-engine/mapping-converter-javascript-android/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.vorto</groupId>
+        <artifactId>mapping-engine</artifactId>
+        <version>0.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>mapping-converter-javascript-android</artifactId>
+    <packaging>aar</packaging>
+    <properties>
+        <!--suppress UnresolvedMavenProperty -->
+        <android.sdk.path>${ANDROID_HOME}</android.sdk.path>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.vorto</groupId>
+            <artifactId>mapping-core-android</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.musala.atmosphere</groupId>
+            <artifactId>openbeans-jxpath</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.LiquidPlayer</groupId>
+            <artifactId>LiquidCore</artifactId>
+            <version>0.5.0</version>
+            <type>aar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/mapping-engine/mapping-converter-javascript-android/src/androidTest/java/org/eclipse/vorto/mapping/engine/converter/android/mapping_converter_javascript_android/ExampleInstrumentedTest.java
+++ b/mapping-engine/mapping-converter-javascript-android/src/androidTest/java/org/eclipse/vorto/mapping/engine/converter/android/mapping_converter_javascript_android/ExampleInstrumentedTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.vorto.mapping.engine.converter.android.mapping_converter_javascript_android;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+    @Test
+    public void useAppContext() {
+        // Context of the app under test.
+        Context appContext = InstrumentationRegistry.getTargetContext();
+
+        assertEquals("org.eclipse.vorto.mapping.engine.converter.android.mapping_converter_javascript_android.test", appContext.getPackageName());
+    }
+}

--- a/mapping-engine/mapping-converter-javascript-android/src/main/AndroidManifest.xml
+++ b/mapping-engine/mapping-converter-javascript-android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.eclipse.vorto.mapping.engine.converter.android.mapping_converter_javascript_android" />

--- a/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptEvalFunction.java
+++ b/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptEvalFunction.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2015-2016 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ */
+package org.eclipse.vorto.mapping.engine.converter.android;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.jxpath.ExpressionContext;
+import org.apache.commons.jxpath.Function;
+import org.apache.commons.jxpath.util.TypeUtils;
+import org.eclipse.vorto.mapping.engine.MappingException;
+import org.liquidplayer.javascript.JSContext;
+import org.liquidplayer.javascript.JSFunction;
+import org.liquidplayer.javascript.JSObject;
+import org.liquidplayer.javascript.JSValue;
+
+
+@SuppressWarnings("restriction")
+public class JavascriptEvalFunction implements Function {
+
+	private static final List<String> MALICIOUS_KEYWORDS = Arrays.asList("while", "for", "foreach");
+
+	private String functionName;
+
+	private String functionBody;
+
+	public JavascriptEvalFunction(String funcName, String funcBody) {
+		this.functionName = funcName;
+		this.functionBody = funcBody;
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes" })
+	public Object invoke(ExpressionContext context, Object[] parameters) {
+		checkScriptForMaliciousContent();
+		JSContext jsContext = new JSContext();
+		jsContext.evaluateScript(functionBody);
+		context.getContextNodeList();
+        // Get Parameters from string
+        Pattern functionParameterPattern = Pattern.compile("function\\s.*?\\(([^)]*)\\)");
+        Matcher functionParameterMatcher = functionParameterPattern.matcher(functionBody);
+        functionParameterMatcher.find();
+        String[] functionParameters = functionParameterMatcher.group(1).split(",");
+
+		// Get JavaScript function body from string which contains the full function block.
+        Pattern functionBodyPattern = Pattern.compile("function\\s*\\w*\\s*\\([\\w\\s,]*\\)\\s*\\{([\\w\\W]*?)\\}");
+        Matcher functionBodyMatcher = functionBodyPattern.matcher(functionBody);
+        functionBodyMatcher.find();
+        functionBody = functionBodyMatcher.group(1);
+
+		JSFunction jsFunction = new JSFunction(jsContext, functionName, functionBody, functionParameters);
+		JSObject jsObject = new JSObject();
+        Object[] args;
+        int pi = 0;
+        Class[] types = toTypes(parameters);
+        if (types.length >= 1 && ExpressionContext.class.isAssignableFrom(types[0])) {
+            pi = 1;
+        }
+        args = new Object[parameters.length + pi];
+        if (pi == 1) {
+            args[0] = context;
+        }
+        for (int i = 0; i < parameters.length; i++) {
+            args[i + pi] = TypeUtils.convert(parameters[i], types[i + pi]);
+        }
+		JSValue result = jsFunction.call(jsObject, unwrap(args));
+		if(result.isUndefined()){
+		    throw new MappingException("Error occurred during JavaScript evaluation");
+        }
+		return result;
+	}
+
+	private void checkScriptForMaliciousContent() {
+		for (String maliciousKeyword : MALICIOUS_KEYWORDS) {
+			if (this.functionBody.contains(maliciousKeyword)) {
+				throw new MappingException(
+						"The keyword " + maliciousKeyword + " is not allowed in javascript function.");
+			}
+		}
+
+	}
+
+	private Object[] unwrap(Object[] wrappedArgs) {
+		List<Object> unwrapped = new ArrayList<Object>();
+		for (Object o : wrappedArgs) {
+			if (o instanceof List<?>) {
+				List<?> args = (List<?>) o;
+				unwrapped.add(args.get(0));
+			} else {
+				unwrapped.add(o);
+			}
+		}
+		return unwrapped.toArray();
+	}
+
+	private Class<?>[] toTypes(Object[] parameters) {
+		List<Class<?>> result = new ArrayList<>();
+		for (@SuppressWarnings("unused")
+		Object o : parameters) {
+			result.add(Object.class);
+		}
+		return result.toArray(new Class[parameters.length]);
+	}
+
+}

--- a/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptEvalProvider.java
+++ b/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptEvalProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-2018 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ */
+package org.eclipse.vorto.mapping.engine.converter.android;
+
+import org.eclipse.vorto.mapping.engine.functions.IScriptEvalProvider;
+import org.eclipse.vorto.mapping.engine.functions.IScriptEvaluator;
+
+public class JavascriptEvalProvider implements IScriptEvalProvider {
+
+	@Override
+	public IScriptEvaluator createEvaluator(String namespace) {
+		return new JavascriptFunctions(namespace);
+	}
+
+}

--- a/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptFunctions.java
+++ b/mapping-engine/mapping-converter-javascript-android/src/main/java/org/eclipse/vorto/mapping/engine/converter/android/JavascriptFunctions.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015-2016 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ */
+package org.eclipse.vorto.mapping.engine.converter.android;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.jxpath.Function;
+import org.apache.commons.jxpath.Functions;
+import org.eclipse.vorto.mapping.engine.functions.IScriptEvaluator;
+import org.eclipse.vorto.mapping.engine.functions.ScriptClassFunction;
+
+public class JavascriptFunctions implements Functions, IScriptEvaluator  {
+	
+	private String namespace;
+	
+	private Map<String, String> functions;
+	
+	public JavascriptFunctions(String namespace)
+	{
+		this.namespace = namespace;
+		this.functions = new HashMap<String, String>();
+	}
+	
+	public void addFunction(String functionName, String functionBody) {
+		this.functions.put(functionName, functionBody);
+	}
+	
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Set getUsedNamespaces() {
+		return Collections.singleton(namespace);
+	}
+
+	@Override
+	public Function getFunction(String namespace, String name, Object[] parameters) {
+		if (!this.namespace.equals(namespace)) {
+			return null;
+		}
+		
+		if (!this.functions.containsKey(name)) {
+			return null;
+		}
+		
+		return new JavascriptEvalFunction(name, functions.get(name));
+	}
+
+	@Override
+	public Functions getFunctions() {
+		return this;
+	}
+
+	@Override
+	public void addScriptFunction(ScriptClassFunction function) {
+		this.functions.put(function.getName(),function.getValue());
+	}
+
+}

--- a/mapping-engine/mapping-converter-javascript-android/src/main/res/values/strings.xml
+++ b/mapping-engine/mapping-converter-javascript-android/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">mapping_converter_javascript_android</string>
+</resources>

--- a/mapping-engine/mapping-core-android/pom.xml
+++ b/mapping-engine/mapping-core-android/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mapping-engine</artifactId>
+        <groupId>org.eclipse.vorto</groupId>
+        <version>0.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mapping-core-android</artifactId>
+
+    <dependencies>
+    <dependency>
+        <groupId>org.eclipse.vorto</groupId>
+        <artifactId>mapping-core</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>commons-jxpath</groupId>
+                <artifactId>commons-jxpath</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+
+    <dependency>
+        <groupId>com.musala.atmosphere</groupId>
+        <artifactId>openbeans-jxpath</artifactId>
+        <version>0.0.1</version>
+    </dependency>
+    </dependencies>
+</project>

--- a/mapping-engine/mapping-engine-android/pom.xml
+++ b/mapping-engine/mapping-engine-android/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.vorto</groupId>
+        <artifactId>mapping-engine</artifactId>
+        <version>0.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>mapping-engine-android</artifactId>
+    <packaging>aar</packaging>
+    <properties>
+        <!--suppress UnresolvedMavenProperty -->
+        <android.sdk.path>${ANDROID_HOME}</android.sdk.path>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.vorto</groupId>
+            <artifactId>mapping-core-android</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.vorto</groupId>
+            <artifactId>mapping-converter-javascript-android</artifactId>
+            <version>${project.version}</version>
+            <type>aar</type>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/mapping-engine/mapping-engine-android/src/androidTest/java/org/eclipse/vorto/mapping/engine/android/ExampleInstrumentedTest.java
+++ b/mapping-engine/mapping-engine-android/src/androidTest/java/org/eclipse/vorto/mapping/engine/android/ExampleInstrumentedTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.vorto.mapping.engine.android;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+    @Test
+    public void useAppContext() {
+        // Context of the app under test.
+        Context appContext = InstrumentationRegistry.getTargetContext();
+
+        assertEquals("org.eclipse.vorto.mapping.engine.android.test", appContext.getPackageName());
+    }
+}

--- a/mapping-engine/mapping-engine-android/src/main/AndroidManifest.xml
+++ b/mapping-engine/mapping-engine-android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.eclipse.vorto.mapping.engine.android" />

--- a/mapping-engine/mapping-engine-android/src/main/java/org/eclipse/vorto/mapping/engine/android/MappingEngine.java
+++ b/mapping-engine/mapping-engine-android/src/main/java/org/eclipse/vorto/mapping/engine/android/MappingEngine.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2015-2018 Bosch Software Innovations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Bosch Software Innovations GmbH - Please refer to git log
+ */
+package org.eclipse.vorto.mapping.engine.android;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import org.eclipse.vorto.mapping.engine.IDataMapper;
+import org.eclipse.vorto.mapping.engine.converter.android.JavascriptEvalProvider;
+import org.eclipse.vorto.mapping.engine.model.spec.IMappingSpecification;
+import org.eclipse.vorto.model.runtime.InfomodelValue;
+import org.eclipse.vorto.model.runtime.PropertyValue;
+
+public final class MappingEngine {
+
+	private IDataMapper mapper;
+	
+	private MappingEngine(IMappingSpecification specification) {
+		mapper = IDataMapper.newBuilder().registerScriptEvalProvider(new JavascriptEvalProvider()).withSpecification(specification).build();
+	}
+	
+	public static MappingEngine create(IMappingSpecification specification) {
+		return new MappingEngine(specification);	
+	}
+	
+	public static MappingEngine createFromInputStream(InputStream inputStream) {
+		IMappingSpecification spec = IMappingSpecification.newBuilder().fromInputStream(inputStream).build();
+		return new MappingEngine(spec);
+	}
+	
+	/**
+	 * Maps the given device source object to Vorto compliant Information Model data.
+	 * @param input source input data that is supposed to get mapped.
+	 * @return mapped payload that complies to Vorto Information Model
+	 */
+	public InfomodelValue map(Object deviceData) {
+		return mapper.mapSource(deviceData);
+	}
+	
+	/**
+	 * Maps the given Functionblock Property to device specific object.
+	 * @param newValue the value to map
+	 * @param oldValue the value that is currently set on the device
+	 * @param infomodelProperty the name of the property defined in the information model
+	 * @return the mapped device specific object
+	 */
+	public Object mapTarget(PropertyValue newValue, Optional<PropertyValue> oldValue, String infomodelProperty) {
+		return mapper.mapTarget(newValue,oldValue,infomodelProperty);
+	}
+}

--- a/mapping-engine/mapping-engine-android/src/main/res/values/strings.xml
+++ b/mapping-engine/mapping-engine-android/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">mapping_engine_android</string>
+</resources>

--- a/mapping-engine/pom.xml
+++ b/mapping-engine/pom.xml
@@ -19,13 +19,16 @@
 	<modules>
 		<module>mapping-core</module>
 		<module>mapping-converter-javascript</module>
+		<module>mapping-converter-javascript-android</module>
 		<module>mapping-converter-string</module>
 		<module>mapping-converter-types</module>
 		<module>mapping-converter-date</module>
 		<module>mapping-converter-binary</module>
 		<module>mapping-serializer</module>
 		<module>mapping-engine-all</module>
-	</modules>
+		<module>mapping-engine-android</module>
+        <module>mapping-core-android</module>
+    </modules>
 
 	<dependencyManagement>
 		<dependencies>
@@ -36,6 +39,40 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.simpligility.maven.plugins</groupId>
+					<artifactId>android-maven-plugin</artifactId>
+					<version>4.5.0</version>
+					<extensions>true</extensions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>com.simpligility.maven.plugins</groupId>
+				<artifactId>android-maven-plugin</artifactId>
+				<configuration>
+					<sdk>
+						<!--suppress UnresolvedMavenProperty -->
+						<path>${android.sdk.path}</path>
+					</sdk>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<!--<source>1.6</source>
+					<target>1.6</target>-->
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
 			<id>eclipse</id>
 			<url>https://repo.eclipse.org/content/repositories/snapshots/</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+		<repository>
+			<id>jcenter</id>
+			<url>https://jcenter.bintray.com/</url>
+		</repository>
 	</repositories>
 
 	<modules>


### PR DESCRIPTION
Adds mapping-converter-javascript-android which takes care of replacing
nashorn with a custom javascript interpreter
Adds mapping-engine-android which is a helper package for the
mapping-core-android packaage
Adds mapping-core-android which wraps mapping-core and replaces jxpath
with an openbeans jxpath version.

Signed-off-by: Fritz Otlinghaus <fritz@otlinghaus.it>