### PR TITLE
[1250] Fix error handling in Generators Health check

### DIFF
--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -229,6 +229,13 @@
 			<artifactId>modeshape-unit-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
+            <version>2.0.2.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/actuator/GeneratorsHealthCheck.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/actuator/GeneratorsHealthCheck.java
@@ -17,7 +17,6 @@ import org.eclipse.vorto.repository.generation.impl.Generator;
 import org.eclipse.vorto.repository.generation.impl.IGeneratorLookupRepository;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 public class GeneratorsHealthCheck implements HealthIndicator {
@@ -35,15 +34,14 @@ public class GeneratorsHealthCheck implements HealthIndicator {
    public Health health() {
       final Iterable<Generator> generators = this.registeredGeneratorsRepository.findAll();
       for ( final Generator generator : generators ) {
-         final ResponseEntity<GeneratorInfo> generatorInfoResponseEntity = restTemplate
-               .getForEntity( generator.getGenerationInfoUrl() + "?includeConfigUI={includeConfigUI}",
-                     GeneratorInfo.class, false );
-
-         if ( !generatorInfoResponseEntity.getStatusCode().is2xxSuccessful() ) {
-            return Health.down()
-                         .withDetail( "Generator down.", String.format( "Generator Key: %s", generator.getKey() ) )
-                         .build();
-         }
+    	  try {
+    		  restTemplate.getForEntity( generator.getGenerationInfoUrl() + "?includeConfigUI={includeConfigUI}",
+    	                     GeneratorInfo.class, false );
+    	  } catch (Exception exception) {
+    		  return Health.down()
+                      .withDetail( "Generator down.", String.format( "Generator Key: %s", generator.getKey() ) )
+                      .build();
+    	  }
       }
       return Health.up().build();
    }

--- a/repository/repository-core/src/test/java/org/eclipse/vorto/repository/actuator/GeneratorsHealthCheckTest.java
+++ b/repository/repository-core/src/test/java/org/eclipse/vorto/repository/actuator/GeneratorsHealthCheckTest.java
@@ -12,8 +12,8 @@
  */
 package org.eclipse.vorto.repository.actuator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 @SpringBootTest( webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT )
 @ContextConfiguration( classes = { TestConfig.class, GeneratorsHealthCheck.class, RestTemplate.class },
                        loader = AnnotationConfigContextLoader.class )
-@AutoConfigureWireMock(port = 8888)
+@AutoConfigureWireMock( port = 8888 )
 public class GeneratorsHealthCheckTest {
 
    private final String infoEndpointResponse = "{\n" +
@@ -60,14 +60,14 @@ public class GeneratorsHealthCheckTest {
    @Autowired
    private GeneratorsHealthCheck generatorsHealthCheck;
 
-   private Generator testGeneratorOne;
-   private Generator testGeneratorTwo;
    private final ArrayList<Generator> generators = new ArrayList<>();
 
    @Before
    public void setUp() {
-      testGeneratorOne = new Generator( "test-generator-one", "http://localhost:8888/test-generator-one", "test" );
-      testGeneratorTwo = new Generator( "test-generator-two", "http://localhost:8888/test-generator-two", "test" );
+      final Generator testGeneratorOne = new Generator( "test-generator-one",
+            "http://localhost:8888/test-generator-one", "test" );
+      final Generator testGeneratorTwo = new Generator( "test-generator-two",
+            "http://localhost:8888/test-generator-two", "test" );
 
       generators.add( testGeneratorOne );
       generators.add( testGeneratorTwo );


### PR DESCRIPTION
By default the Error Handler for the Spring Rest-Template throws an
exception when the status code in a response is not 2xx.
Hence the check whether a Generator is available is changed from
checking the status code to handling the exception thrown by the
Rest-Templates error handler.

Signed-off-by: Schmidt-Dumont Georg (BCI/ESW24) <georg.schmidt-dumont@de.bosch.com>