### PR TITLE
Remove MaxPermSize from jvm options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 					<junitArtifactName>junit:junit</junitArtifactName>
 					<encoding>UTF-8</encoding>
 					<inputEncoding>UTF-8</inputEncoding>
-					<argLine>-Xms256m -Xmx512m -XX:MaxPermSize=128m -ea
+					<argLine>-Xms256m -Xmx512m -ea
 						-Dfile.encoding=UTF-8</argLine>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
MaxPermSize was removed in Java8 so no reason for keeping it.