### PR TITLE
Bug/issue 1359 fix for clm scans

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -51,14 +51,35 @@
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-webmvc</artifactId>
 					</exclusion>
-				</exclusions>
-			</dependency>
+          <exclusion>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>5.1.17.Final</version>
+      </dependency>
+      <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-entitymanager -->
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-entitymanager</artifactId>
+        <version>5.1.17.Final</version>
+      </dependency>
+
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-log4j</artifactId>
 				<version>1.3.8.RELEASE</version>
 			</dependency>
-                        
+
 			<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
                         <dependency>
 				<groupId>org.springframework</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -222,24 +222,6 @@
 				<groupId>org.webjars</groupId>
 				<artifactId>angular-ui-bootstrap</artifactId>
 				<version>0.14.3</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.webjars</groupId>
-						<artifactId>bootstrap</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<!-- https://mvnrepository.com/artifact/org.webjars/bootstrap -->
-			<dependency>
-			    <groupId>org.webjars</groupId>
-			    <artifactId>bootstrap</artifactId>
-			    <version>3.4.1</version>
-			    <exclusions>
-					<exclusion>
-						<groupId>org.webjars</groupId>
-						<artifactId>jquery</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -51,29 +51,8 @@
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-webmvc</artifactId>
 					</exclusion>
-          <exclusion>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
-      <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>5.1.17.Final</version>
-      </dependency>
-      <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-entitymanager -->
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-entitymanager</artifactId>
-        <version>5.1.17.Final</version>
-      </dependency>
-
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-log4j</artifactId>
@@ -81,7 +60,7 @@
 			</dependency>
 
 			<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
-                        <dependency>
+      <dependency>
 				<groupId>org.springframework</groupId>
     				<artifactId>spring-web</artifactId>
     				<version>4.3.20.RELEASE</version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -243,6 +243,24 @@
 				<groupId>org.webjars</groupId>
 				<artifactId>angular-ui-bootstrap</artifactId>
 				<version>0.14.3</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.webjars</groupId>
+						<artifactId>bootstrap</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<!-- https://mvnrepository.com/artifact/org.webjars/bootstrap -->
+			<dependency>
+			    <groupId>org.webjars</groupId>
+			    <artifactId>bootstrap</artifactId>
+			    <version>3.4.1</version>
+			    <exclusions>
+					<exclusion>
+						<groupId>org.webjars</groupId>
+						<artifactId>jquery</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>

--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -165,8 +165,20 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.1.17.Final</version>
+    </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>

--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.16.RELEASE</version>
+			<version>2.0.17.RELEASE</version>
 		</dependency>
 		<dependency>
             <groupId>org.springframework.boot</groupId>
@@ -225,7 +225,7 @@
 			<artifactId>modeshape-unit-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>

--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -182,6 +182,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+			<exclusions>
+				<exclusion>
+				 <groupId>org.springframework.security</groupId>
+				 <artifactId>spring-security-web</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-web -->
+		<dependency>
+		    <groupId>org.springframework.security</groupId>
+		    <artifactId>spring-security-web</artifactId>
+		    <version>4.2.9.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>

--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -108,7 +108,19 @@
 		<dependency>
 			<groupId>org.modeshape</groupId>
 			<artifactId>modeshape-jcr</artifactId>
-		</dependency>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tika</groupId>
+          <artifactId>tika-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.tika/tika-core -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>1.20</version>
+    </dependency>
 		<dependency>
 			<groupId>org.modeshape</groupId>
 			<artifactId>modeshape-jcr-api</artifactId>

--- a/repository/repository-core/pom.xml
+++ b/repository/repository-core/pom.xml
@@ -108,18 +108,6 @@
 		<dependency>
 			<groupId>org.modeshape</groupId>
 			<artifactId>modeshape-jcr</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tika</groupId>
-          <artifactId>tika-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.tika/tika-core -->
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>1.20</version>
     </dependency>
 		<dependency>
 			<groupId>org.modeshape</groupId>
@@ -166,18 +154,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate</groupId>
-          <artifactId>hibernate-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>5.1.17.Final</version>
     </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/repository/repository-server-config/pom.xml
+++ b/repository/repository-server-config/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.16.RELEASE</version>
+			<version>2.0.17.RELEASE</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-commons -->

--- a/repository/repository-server-config/pom.xml
+++ b/repository/repository-server-config/pom.xml
@@ -43,6 +43,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+			<exclusions>
+				<exclusion>
+				 <groupId>org.springframework.security</groupId>
+				 <artifactId>spring-security-web</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-web -->
+		<dependency>
+		    <groupId>org.springframework.security</groupId>
+		    <artifactId>spring-security-web</artifactId>
+		    <version>4.2.9.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>

--- a/repository/repository-server/pom.xml
+++ b/repository/repository-server/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.16.RELEASE</version>
+			<version>2.0.17.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/repository/repository-server/pom.xml
+++ b/repository/repository-server/pom.xml
@@ -58,6 +58,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+			<exclusions>
+				<exclusion>
+				 <groupId>org.springframework.security</groupId>
+				 <artifactId>spring-security-web</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-web -->
+		<dependency>
+		    <groupId>org.springframework.security</groupId>
+		    <artifactId>spring-security-web</artifactId>
+		    <version>4.2.9.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>


### PR DESCRIPTION
Fixes #1359 

Following are the jars upgraded to :
* org.springframework.security.oauth : spring-security-oauth2 : 2.0.17.RELEASE
* org.springframework.security : spring-security-web : 4.2.9.RELEASE
* org.hibernate : hibernate-core : 5.1.17.Final
* org.hibernate : hibernate-entitymanager : 5.1.17.Final
* org.apache.tika : tika-core : 1.20
* org.webjars : bootstrap : 3.4.1
