### PR TITLE
Fixes #1575 - Model Promoter is not able to deprecate models in tenant.

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/workflow/impl/conditions/HasRoleCondition.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/workflow/impl/conditions/HasRoleCondition.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.workflow.impl.conditions;
+
+import org.eclipse.vorto.repository.account.IUserAccountService;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.eclipse.vorto.repository.domain.Role;
+import org.eclipse.vorto.repository.domain.User;
+import org.eclipse.vorto.repository.workflow.model.IWorkflowCondition;
+
+public class HasRoleCondition implements IWorkflowCondition {
+
+  private IUserAccountService userRepository;
+  private Role role;
+
+  public HasRoleCondition(IUserAccountService userRepository, Role role) {
+    this.userRepository = userRepository;
+    this.role = role;
+  }
+
+  @Override
+  public boolean passesCondition(ModelInfo model, IUserContext user) {
+    User foundUser = userRepository.getUser(user.getUsername());
+    return foundUser != null ? foundUser.hasRole(user.getTenant(), role) : false;
+  }
+}

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/workflow/impl/functions/GrantModelOwnerPolicy.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/workflow/impl/functions/GrantModelOwnerPolicy.java
@@ -43,6 +43,7 @@ public class GrantModelOwnerPolicy implements IWorkflowFunction {
         PolicyEntry.of(model.getAuthor(), PrincipalType.User, Permission.FULL_ACCESS),
         PolicyEntry.of(Role.USER.name(), PrincipalType.Role, Permission.READ),
         PolicyEntry.of(Role.MODEL_CREATOR.name(), PrincipalType.Role, Permission.FULL_ACCESS),
+        PolicyEntry.of(Role.MODEL_PROMOTER.name(), PrincipalType.Role, Permission.FULL_ACCESS),
         PolicyEntry.of(Role.SYS_ADMIN.name(), PrincipalType.Role, Permission.FULL_ACCESS));
   }
 }

--- a/repository/repository-core/src/test/java/org/eclipse/vorto/repository/AbstractIntegrationTest.java
+++ b/repository/repository-core/src/test/java/org/eclipse/vorto/repository/AbstractIntegrationTest.java
@@ -109,13 +109,16 @@ public abstract class AbstractIntegrationTest {
     when(userRepository.findByUsername("admin")).thenReturn(getUser("admin", playgroundTenant));
 
     when(userRepository.findByUsername("creator")).thenReturn(getUser("creator", playgroundTenant));
+    
+    when(userRepository.findByUsername("promoter")).thenReturn(getUser("promoter", playgroundTenant));
 
     when(userRepository.findByUsername("reviewer"))
         .thenReturn(getUser("reviewer", playgroundTenant));
 
     when(userRepository.findAll()).thenReturn(Lists.newArrayList(getUser("admin", playgroundTenant),
         getUser("erle", playgroundTenant), getUser("alex", playgroundTenant),
-        getUser("creator", playgroundTenant), getUser("reviewer", playgroundTenant)));
+        getUser("creator", playgroundTenant), getUser("reviewer", playgroundTenant), 
+        getUser("promoter", playgroundTenant)));
 
     when(tenantService.getTenant("playground")).thenReturn(Optional.of(playgroundTenant));
     when(tenantService.getTenants()).thenReturn(Lists.newArrayList(playgroundTenant));
@@ -258,6 +261,7 @@ public abstract class AbstractIntegrationTest {
     playground.addUser(createTenantUser("admin",
         Sets.newHashSet(roleUser, roleCreator, rolePromoter, roleReviewer, roleSysAdmin)));
     playground.addUser(createTenantUser("creator", Sets.newHashSet(roleUser, roleCreator)));
+    playground.addUser(createTenantUser("promoter", Sets.newHashSet(roleUser, rolePromoter)));
     playground.addUser(createTenantUser("reviewer", Sets.newHashSet(roleUser, roleReviewer)));
 
     return playground;

--- a/repository/repository-core/src/test/java/org/eclipse/vorto/repository/workflow/WorkflowTest.java
+++ b/repository/repository-core/src/test/java/org/eclipse/vorto/repository/workflow/WorkflowTest.java
@@ -61,7 +61,7 @@ public class WorkflowTest extends AbstractIntegrationTest {
     ModelInfo model = importModel("creator", "Color.type");
     IUserContext user = createUserContext("creator", "playground");
     workflow.start(model.getId(), user);
-    model = workflow.doAction(model.getId(), createUserContext("creator", "playground"),
+    model = workflow.doAction(model.getId(), createUserContext("promoter", "playground"),
         SimpleWorkflowModel.ACTION_RELEASE.getName());
     assertEquals(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), model.getState());
     assertEquals(0,
@@ -70,7 +70,7 @@ public class WorkflowTest extends AbstractIntegrationTest {
         workflow.getModelsByState(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), user).size());
 
     assertEquals(1, workflow
-        .getPossibleActions(model.getId(), createUserContext("creator", "playground")).size());
+        .getPossibleActions(model.getId(), createUserContext("promoter", "playground")).size());
   }
 
   @Test(expected = WorkflowException.class)
@@ -85,18 +85,18 @@ public class WorkflowTest extends AbstractIntegrationTest {
   public void testApproveModelByAdminInReviewState() throws Exception {
     ModelInfo model = importModel("creator", "Color.type");
     IUserContext creator = createUserContext("creator", "playground");
-    IUserContext admin = createUserContext("admin", "playground");
+    IUserContext promoter = createUserContext("promoter", "playground");
+    IUserContext reviewer = createUserContext("reviewer", "playground");
 
     workflow.start(model.getId(), creator);
 
-    model = workflow.doAction(model.getId(), creator, SimpleWorkflowModel.ACTION_RELEASE.getName());
+    model = workflow.doAction(model.getId(), promoter, SimpleWorkflowModel.ACTION_RELEASE.getName());
     assertEquals(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), model.getState());
 
-    assertEquals(1, workflow.getPossibleActions(model.getId(), creator).size());
-    assertEquals(2, workflow
-        .getPossibleActions(model.getId(), createUserContext("admin", "playground")).size());
+    assertEquals(1, workflow.getPossibleActions(model.getId(), promoter).size());
+    assertEquals(2, workflow.getPossibleActions(model.getId(), reviewer).size());
 
-    model = workflow.doAction(model.getId(), admin, SimpleWorkflowModel.ACTION_APPROVE.getName());
+    model = workflow.doAction(model.getId(), reviewer, SimpleWorkflowModel.ACTION_APPROVE.getName());
     assertEquals(1,
         workflow.getModelsByState(SimpleWorkflowModel.STATE_RELEASED.getName(), creator).size());
     assertEquals(0,
@@ -110,12 +110,13 @@ public class WorkflowTest extends AbstractIntegrationTest {
   public void testApproveModelByModelReviewerInReviewState() throws Exception {
     ModelInfo model = importModel("creator", "Color.type");
     IUserContext user = createUserContext("creator", "playground");
+    IUserContext promoter = createUserContext("promoter", "playground");
     workflow.start(model.getId(), user);
 
-    model = workflow.doAction(model.getId(), user, SimpleWorkflowModel.ACTION_RELEASE.getName());
+    model = workflow.doAction(model.getId(), promoter, SimpleWorkflowModel.ACTION_RELEASE.getName());
     assertEquals(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), model.getState());
 
-    assertEquals(1, workflow.getPossibleActions(model.getId(), user).size());
+    assertEquals(1, workflow.getPossibleActions(model.getId(), promoter).size());
     assertEquals(2, workflow
         .getPossibleActions(model.getId(), createUserContext("reviewer", "playground")).size());
     model = workflow.doAction(model.getId(), createUserContext("reviewer", "playground"),
@@ -132,13 +133,14 @@ public class WorkflowTest extends AbstractIntegrationTest {
   @Test
   public void testRejectModelByModelReviewerInReviewState() throws Exception {
     ModelInfo model = importModel("creator", "Color.type");
-    IUserContext user = createUserContext("creator", "playground");
-    workflow.start(model.getId(), user);
+    IUserContext creator = createUserContext("creator", "playground");
+    IUserContext promoter = createUserContext("promoter", "playground");
+    workflow.start(model.getId(), creator);
 
-    model = workflow.doAction(model.getId(), user, SimpleWorkflowModel.ACTION_RELEASE.getName());
+    model = workflow.doAction(model.getId(), promoter, SimpleWorkflowModel.ACTION_RELEASE.getName());
     assertEquals(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), model.getState());
 
-    assertEquals(1, workflow.getPossibleActions(model.getId(), user).size());
+    assertEquals(1, workflow.getPossibleActions(model.getId(), promoter).size());
 
     assertEquals(2, workflow
         .getPossibleActions(model.getId(), createUserContext("reviewer", "playground")).size());
@@ -147,22 +149,21 @@ public class WorkflowTest extends AbstractIntegrationTest {
         SimpleWorkflowModel.ACTION_REJECT.getName());
 
     assertEquals(0,
-        workflow.getModelsByState(SimpleWorkflowModel.STATE_RELEASED.getName(), user).size());
+        workflow.getModelsByState(SimpleWorkflowModel.STATE_RELEASED.getName(), creator).size());
     assertEquals(0,
-        workflow.getModelsByState(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), user).size());
+        workflow.getModelsByState(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), creator).size());
     assertEquals(1,
-        workflow.getModelsByState(SimpleWorkflowModel.STATE_DRAFT.getName(), user).size());
-    assertEquals(1, workflow
-        .getPossibleActions(model.getId(), createUserContext("creator", "playground")).size());
+        workflow.getModelsByState(SimpleWorkflowModel.STATE_DRAFT.getName(), creator).size());
+    assertEquals(1, workflow.getPossibleActions(model.getId(), promoter).size());
   }
 
   @Test(expected = WorkflowException.class)
   public void testApproveModelByUserInReviewState() throws Exception {
     ModelInfo model = importModel("creator", "Color.type");
-    IUserContext creator = createUserContext("alex", "playground");
+    IUserContext creator = createUserContext("creator", "playground");
     workflow.start(model.getId(), creator);
 
-    model = workflow.doAction(model.getId(), creator, SimpleWorkflowModel.ACTION_RELEASE.getName());
+    model = workflow.doAction(model.getId(), createUserContext("promoter", "playground"), SimpleWorkflowModel.ACTION_RELEASE.getName());
     assertEquals(SimpleWorkflowModel.STATE_IN_REVIEW.getName(), model.getState());
     model = workflow.doAction(model.getId(), creator, SimpleWorkflowModel.ACTION_APPROVE.getName());
   }


### PR DESCRIPTION
Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>