### PR TITLE
Revert back the usage of semicolon.

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/account/impl/DefaultUserAccountService.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/account/impl/DefaultUserAccountService.java
@@ -51,7 +51,7 @@ public class DefaultUserAccountService
     implements IUserAccountService, ApplicationEventPublisherAware {
 
   @Value("${server.admin:#{null}}")
-  private String admins;
+  private String[] admins;
 
   @Autowired
   private IUserRepository userRepository;
@@ -184,7 +184,7 @@ public class DefaultUserAccountService
   }
 
   private boolean isConfiguredAsAdmin(String username) {
-    return admins != null && Arrays.asList(admins.split(";")).contains(username);
+    return admins != null && Arrays.asList(admins).contains(username);
   }
 
   @Transactional

--- a/repository/repository-server/src/main/resources/application.yml
+++ b/repository/repository-server/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 8080
   contextPath: /infomodelrepository
   use-forward-headers: true
-  admin: aedelmann;erlemantos
+  admin: aedelmann, erlemantos
   config:
     authenticatedSearchMode: false
     generatorUser: generator


### PR DESCRIPTION
This fixes #1591 - Setting multiple admins causes AWS problems

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>