### PR TITLE
Avoid image distortion

### DIFF
--- a/repository/repository-web/dist/css/style.css
+++ b/repository/repository-web/dist/css/style.css
@@ -465,7 +465,6 @@ ul.nav {
 }
 
 .placeHolder {
-    background-color: #dadada;
     height: 200px;
     width: 200px;
     display: -webkit-flex;
@@ -482,7 +481,9 @@ ul.nav {
     text-align: center;
     padding: 3px 0;
     background: #dadada;
-
+    width: 200px;
+    height: 200px;
+    line-height: 200px;
 }
 
 .placeHolder:hover .noimg{

--- a/repository/repository-web/dist/partials/details-template.html
+++ b/repository/repository-web/dist/partials/details-template.html
@@ -108,7 +108,7 @@
 												<div class="placeHolder">
 													<div class="noimg" ng-show="!model.hasImage">No Image Yet
 													</div>
-													<img ng-if="model.hasImage" ng-src="rest/models/{{model.id.prettyFormat}}/images" width="200" height="200" />
+													<img ng-if="model.hasImage" ng-src="rest/models/{{model.id.prettyFormat}}/images" max-width="200" max-height="200" />
 													<div class="upload" ng-show="(hasAuthority('ROLE_SYS_ADMIN') || permission === 'FULL_ACCESS' || permission === 'MODIFY')  && model.type === 'InformationModel'">
 														<a href="" ng-click="chooseImageFile()">
 															<i class="fa fa-upload"></i> Click to change image</a>


### PR DESCRIPTION
#### This PR fixes #1812

- [x] Change `width` and `height` of img to `max-width` and `max-height`
- [x] Remove background color of `placeholder` div to avoid grey background on smaller img
- [x] resize `noImg` div element to be full size with grey background if there is no image
- [x] center `No Img uploaded` text with css using `line-height`

--- 

Ready for review @aedelmann 