### PR TITLE
When checking if a certain node exist, if modeshape throws an NPE, ca…

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/ModelRepository.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/ModelRepository.java
@@ -878,6 +878,8 @@ public class ModelRepository extends AbstractRepositoryOperation
       try {
         ModelIdHelper modelIdHelper = new ModelIdHelper(modelId);
         return session.itemExists(modelIdHelper.getFullPath());
+      } catch (NullPointerException e) {
+        return false;
       } catch (AccessDeniedException e) {
         return true;
       }

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/diagnostics/ModelValidationDiagnostic.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/diagnostics/ModelValidationDiagnostic.java
@@ -70,7 +70,7 @@ public class ModelValidationDiagnostic implements NodeDiagnostic {
             e.getMessage()));
       } catch (NotAuthorizedException e) {
           diagnostics.add(new Diagnostic(e.getModelId(),"Not authorized to view model '"+e.getModelId().getPrettyFormat()+"'"));
-      }catch (Exception e) {
+      } catch (Exception e) {
         logger.error("Caught error in diagnosing '" + node + "'", e);
         diagnostics.add(new Diagnostic(NodeDiagnosticUtils.getModelId(node.getPath()).orElse(null),
             NodeDiagnosticUtils.compileErrorMessage(e)));


### PR DESCRIPTION
…tch it and assume that that node doesn't exist.

Sometimes, session.itemExists throws an NPE. This patch catches that exception and returns
false, signifying that the particular model path is empty.

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>