### PR TITLE
Fixes #1989 Update the docker docs and variables

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -2,16 +2,21 @@
 # Vorto Docker Images
 
 ## Quickstart
+
 Eager to try out the vorto model repository? This section gives a good introduction on howto set up your repository in a couple of minutes.
 It assumes you already have `docker-compose` installed and created an GitHub OAuth App. If you do not, head over to the [docker installation](https://docs.docker.com/compose/install/).
+
 Also a valid oauth token is required, follow the GitHub OAuth App section lower down on this page to obtain one.
+
 Everything read? Great lets get you started:
+
 To get the docker-compose file clone the github repository by running:
 `git clone https://github.com/eclipse/vorto.git vorto`
 
 After thats done we need to update the `vorto-variables.env` its located under `docker/vorto-variables.env`
 
 Update all the placeholders and save your progress, it should look something like this:
+
 ```bash
 # Generell settings
 GENERATOR_PASSWORD=<your_generator_password>
@@ -23,7 +28,6 @@ GITHUB_CLIENT_SECRET=<your_github_client_secret>
 
 # Generators
 VORTO_URL=http://repository:8080
-SERVICE_URL=http://generators:8080
 
 #proxy
 #http_proxy=http://user:password@proxy.com:port
@@ -45,12 +49,35 @@ To get some models to play around with, login
 ![login view](docs/inital_view.png)
 
 Go to import
+
 ![import button](docs/import_highlight.png)
 
 And upload `docker/MyFirstModel_1.0.0.zip`
+
 ![import view](docs/import_view.png)
 
 Thats it you now should have a working instance of the Vorto Repository.
+
+## Configure 3rd party generators
+
+Generators using APIv2 are registered via a base64 encoded string, containing a JSON object, stored in the environment variable `PLUGINS`. The stored array of plugins looks like the following.
+
+```json
+[
+    {
+        "key": "mygenerator",
+        "pluginType": "generator",
+        "apiVersion": "2",
+        "endpoint": "http://3rd-party-generator:8080"
+    }
+]
+```
+
+The generator might be provided via AWS, Docker or anything else you can imagine.
+
+Some plugins that are also used on [vorto.eclipse.org](https://vorto.eclipse.org) can be found under `/repository/repository-server/target/classes/application-local-https.yml`.
+
+## Configuration environment variables
 
 | Variable name          | default/required             | used in repository       | used in generator runner | description                                                                                                                                                                                                                          |
 |------------------------|------------------------------|--------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -61,6 +88,7 @@ Thats it you now should have a working instance of the Vorto Repository.
 | `EIDP_CLIENT_SECRET`   | :heavy_check_mark:           | :heavy_check_mark:       | :heavy_multiplication_x: | eidp Oauth client secret. Only required when using `eidp` as auth provider.                                                                                                                                                          |
 | `VORTO_URL`            | :heavy_check_mark:           | :heavy_multiplication_x: | :heavy_check_mark:       | Url the repository is listing under, for the generators to register to.                                                                                                                                                              |
 | `SERVICE_URL`          | :heavy_check_mark:           | :heavy_multiplication_x: | :heavy_check_mark:       | The url the generators are running under to provide a callback method for the repository                                                                                                                                             |
+| `PLUGINS`              | :heavy_multiplication_x:     | :heavy_check_mark:       | :heavy_multiplication_x: | A base64 encoded string of a JSON array containing all registered plugins since APIv2                                                                                                                                                |
 | `GENERATOR_PASSWORD`   | :heavy_check_mark:           | :heavy_check_mark:       | :heavy_check_mark:       | The password a generator uses to authenticate against the repository.                                                                                                                                                                |
 | `GENERATOR_USER`       | `vorto_generators`           | :heavy_check_mark:       | :heavy_check_mark:       | The user a generator uses to authenticate against the repository.                                                                                                                                                                    |
 | `VORTO_PORT`           | `8080`                       | :heavy_check_mark:       | :heavy_check_mark:       | The port used for the application running in the docker container.                                                                                                                                                                   |
@@ -74,7 +102,9 @@ Thats it you now should have a working instance of the Vorto Repository.
 | `http_proxy`           | :heavy_multiplication_x:     | :heavy_check_mark:       | :heavy_check_mark:       | Proxy variable that takes in an http proxy to tunnle requests through. This is required for any repository that runs behind a proxy to contact the oauth provider. Format: `http://user:password@proxy:port` or `http://proxy:port`  |
 | `https_proxy`          | :heavy_multiplication_x:     | :heavy_check_mark:       | :heavy_check_mark:       | Proxy variable that takes in an http proxy to tunnle requests through. This is required for any repository that runs behind a proxy to contact the oauth provider. Format: `https://user:password@proxy:port` or `http://proxy:port` |
 | `no_proxy`             | :heavy_multiplication_x:     | :heavy_check_mark:       | :heavy_check_mark:       | A comma seperated list of host for which to bypass the configured proxy. Keep in mind that the container have to talk to each other.                                                                                                 |
+
 ## GitHub OAuth App
+
 * Open [the github developers page](https://github.com/settings/developers)
 * Under Settings->Developer Settings->OAuth Apps click `Register a new application`
 * Fill in the `Application name` with what ever you want, we are using `Vorto Local`

--- a/docker/vorto-variables.env
+++ b/docker/vorto-variables.env
@@ -1,12 +1,11 @@
 # Generell settings
-http_proxy=http://username:password@proxy.com:8080
-https_proxy=http://username:password@proxy.com:8080
-no_proxy=localhost,generators,db
+#http_proxy=http://username:password@proxy.com:8080
+#https_proxy=http://username:password@proxy.com:8080
+#no_proxy=localhost,generators,db
 VORTO_PORT=8080
 CONTEXT_PATH=/
 GENERATOR_PASSWORD=test
 GENERATOR_USER=vorto_generators
-
 
 # Repository
 DATASOURCE=mysql
@@ -19,11 +18,9 @@ EIDP_CLIENT_SECRET=
 
 # Generators
 VORTO_URL=http://repository:8080
-SERVICE_URL=http://generators:8080
 
 # 3rd-party Generators
-VORTO_URL=http://repository:8080
-3RD_PARTY_SERVICE_URL=http://3rd-party-generators:8080
+#PLUGINS=<base64-encoded-json>
 
 # database
 MYSQL_URL=jdbc:mysql://db:3306/vorto

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -87,6 +87,10 @@ If you want to see the full process of creating, integrating and visualizing sen
   - [Eclipse Hono](../generators/generator-eclipsehono/Readme.md)
   - [OpenAPI](../generators/generator-openapi/Readme.md)
 
+#### Operators Guide
+
+- [Getting started with running the Repository with docker](../docker/Readme.md)
+
 #### Developer Guide
 
 - [Developing Vorto Plugins](../plugin-sdk/Readme.md)


### PR DESCRIPTION
Comment http proxy settings from docker env

It is a more sane value to not set these variables per default with
dummy values. Instead these should be commented out but present for
reference.

Update readme md formatting with linter defaults

Remove plugin apiv1 variables from example

The variables VORTO_URL and SERVICE_URL are not needed anymore in vorto
0.11 and newer, since plugins are now registered via the PLUGINS env
variable.

Fixes #1989