### PR TITLE
Fixes #1991 Add docs and example var for plugin registration

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -52,6 +52,27 @@ And upload `docker/MyFirstModel_1.0.0.zip`
 
 Thats it you now should have a working instance of the Vorto Repository.
 
+## Configure 3rd party generators
+
+Generators using APIv2 are registered via a base64 encoded string, containing a JSON object, stored in the environment variable `PLUGINS`. The stored array of plugins looks like the following.
+
+```json
+[
+    {
+        "key": "mygenerator",
+        "pluginType": "generator",
+        "apiVersion": "2",
+        "endpoint": "http://3rd-party-generator:8080"
+    }
+]
+```
+
+The generator might be provided via AWS, Docker or anything else you can imagine.
+
+Some plugins that are also used on [vorto.eclipse.org](https://vorto.eclipse.org) can be found under `/repository/repository-server/target/classes/application-local-https.yml`.
+
+## Configuration environment variables
+
 | Variable name          | default/required             | used in repository       | used in generator runner | description                                                                                                                                                                                                                          |
 |------------------------|------------------------------|--------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ADMIN_USER`           | :heavy_check_mark:           | :heavy_check_mark:       | :heavy_multiplication_x: | The username of the admin user                                                                                                                                                                                                       |
@@ -61,6 +82,7 @@ Thats it you now should have a working instance of the Vorto Repository.
 | `EIDP_CLIENT_SECRET`   | :heavy_check_mark:           | :heavy_check_mark:       | :heavy_multiplication_x: | eidp Oauth client secret. Only required when using `eidp` as auth provider.                                                                                                                                                          |
 | `VORTO_URL`            | :heavy_check_mark:           | :heavy_multiplication_x: | :heavy_check_mark:       | Url the repository is listing under, for the generators to register to.                                                                                                                                                              |
 | `SERVICE_URL`          | :heavy_check_mark:           | :heavy_multiplication_x: | :heavy_check_mark:       | The url the generators are running under to provide a callback method for the repository                                                                                                                                             |
+| `PLUGINS`              | :heavy_multiplication_x:     | :heavy_check_mark:       | :heavy_multiplication_x: | A base64 encoded string of a JSON array containing all registered plugins since APIv2                                                                                                                                                |
 | `GENERATOR_PASSWORD`   | :heavy_check_mark:           | :heavy_check_mark:       | :heavy_check_mark:       | The password a generator uses to authenticate against the repository.                                                                                                                                                                |
 | `GENERATOR_USER`       | `vorto_generators`           | :heavy_check_mark:       | :heavy_check_mark:       | The user a generator uses to authenticate against the repository.                                                                                                                                                                    |
 | `VORTO_PORT`           | `8080`                       | :heavy_check_mark:       | :heavy_check_mark:       | The port used for the application running in the docker container.                                                                                                                                                                   |

--- a/docker/vorto-variables.env
+++ b/docker/vorto-variables.env
@@ -24,6 +24,7 @@ SERVICE_URL=http://generators:8080
 # 3rd-party Generators
 VORTO_URL=http://repository:8080
 3RD_PARTY_SERVICE_URL=http://3rd-party-generators:8080
+#PLUGINS=<base64-encoded-json>
 
 # database
 MYSQL_URL=jdbc:mysql://db:3306/vorto

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -87,6 +87,10 @@ If you want to see the full process of creating, integrating and visualizing sen
   - [Eclipse Hono](../generators/generator-eclipsehono/Readme.md)
   - [OpenAPI](../generators/generator-openapi/Readme.md)
 
+#### Operators Guide
+
+- [Getting started with running the Repository with docker](../docker/Readme.md)
+
 #### Developer Guide
 
 - [Developing Vorto Plugins](../plugin-sdk/Readme.md)


### PR DESCRIPTION
To make the life of a new operator of a vorto repository easier there now
is a section on configuration of 3rd party generators via the PLUGINS
variable.

There is also a link to one of the profile config files containing an
example array of plugins hosted on AWS, so the operator may gain some
insight on how this could look like.

Add reference to docker docs to getting started

The getting started guide should also feature a guide for operators
containing a link to the README of the docker deployment.

Fixes #1991 

Signed-off-by: Alexander Wellbrock <a.wellbrock@mailbox.org>