### PR TITLE
Add session timeout warning. Fixes #1735

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/SessionTimeoutController.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/SessionTimeoutController.java
@@ -1,0 +1,19 @@
+package org.eclipse.vorto.repository.web.account;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SessionTimeoutController {
+
+  @GetMapping(path = "rest/config/session/timeout")
+  public ResponseEntity<Integer> getSessionTimeout(HttpServletRequest request) {
+    return new ResponseEntity<>(request.getSession().getMaxInactiveInterval(), HttpStatus.OK);
+  }
+
+}

--- a/repository/repository-web/dist/css/style.css
+++ b/repository/repository-web/dist/css/style.css
@@ -1914,3 +1914,12 @@ input[type=file]::-webkit-file-upload-button {
 .alert-danger-break-word {
 	overflow-wrap: break-word;
 }
+
+.alert-danger-stick-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 100%;
+  z-index: 2000;
+  text-align: center;
+}

--- a/repository/repository-web/dist/js/controllers/detailsController.js
+++ b/repository/repository-web/dist/js/controllers/detailsController.js
@@ -2,10 +2,10 @@ define(["../init/appController"],function(repositoryControllers) {
 
 repositoryControllers.controller('DetailsController', 
     ['$q','$rootScope', '$scope', '$http', '$routeParams', '$location', '$route', 
-     '$uibModal', '$timeout', '$window', '$timeout', 'openCreateModelDialog', 
-     'TenantService', 'confirmPublish',
+     '$uibModal', '$window', '$timeout', 'openCreateModelDialog',
+     'TenantService', 'confirmPublish', 'SessionTimeoutService',
     function ($q, $rootScope, $scope, $http, $routeParams, $location, $route, $uibModal, 
-        $timeout, $window, $timeout, openCreateModelDialog, TenantService, confirmPublish) {
+        $window, $timeout, openCreateModelDialog, TenantService, confirmPublish, sessionTimeoutService) {
 
 		$scope.model = [];
 		$scope.aclEntries = [];
@@ -25,7 +25,7 @@ repositoryControllers.controller('DetailsController',
 		$scope.attachments = [];
 		$scope.permission = "READ";
 		$scope.encodeURIComponent = encodeURIComponent;
-		$scope.newComment = {value: ""}
+		$scope.newComment = {value: ""};
 		$scope.canGenerate = true;
 		
 		$scope.editorConfig = {
@@ -45,10 +45,12 @@ repositoryControllers.controller('DetailsController',
 	        syntaxDefinition: "webjars/repository-web/dist/js/ace-modes/mode-mapping",
 	        serviceUrl: "mapping/xtext-service"
 	      }
-    	}
-		
+    	};
+
+		sessionTimeoutService.initSessionTimeoutWarning($scope);
+
 		$scope.createEditor = function(model) {
-			var language = ""
+			var language = "";
 			if (model.type === 'Datatype') {
 				language = "type";
 			} else if (model.type === 'Functionblock') {
@@ -58,7 +60,7 @@ repositoryControllers.controller('DetailsController',
 			} else {
 				language = "mapping";
 			}
-		
+
 			var defer = $q.defer();
 			require(["webjars/ace/src/ace"], function() {
 	    		require(["xtext/xtext-ace"], function(xtext) {
@@ -336,7 +338,6 @@ repositoryControllers.controller('DetailsController',
 
 		$scope.listToMatrix = function (list, n) {
 			var grid = [],
-				i = 0,
 				x = list.length,
 				col, row = -1;
 			for (var i = 0; i < x; i++) {
@@ -347,7 +348,7 @@ repositoryControllers.controller('DetailsController',
 				grid[row][col] = list[i];
 			}
 			return grid;
-		}
+		};
 
 		$scope.modelId = $routeParams.modelId;
 		

--- a/repository/repository-web/dist/js/controllers/mapping/mappingbuilder-controller.js
+++ b/repository/repository-web/dist/js/controllers/mapping/mappingbuilder-controller.js
@@ -1,7 +1,7 @@
 define(["../../init/appController"],function(repositoryControllers) {
 
-repositoryControllers.controller("MappingBuilderController", ["$rootScope","$uibModal", "$routeParams", "$scope", "$location","$http", "$sce","$timeout",
-    function($rootScope,$uibModal,$routeParams, $scope, $location,$http, $sce,$timeout) {
+repositoryControllers.controller("MappingBuilderController", ["$rootScope","$uibModal", "$routeParams", "$scope", "$location","$http", "$sce","$timeout", "SessionTimeoutService",
+    function($rootScope,$uibModal,$routeParams, $scope, $location,$http, $sce, $timeout, sessionTimeoutService) {
 
     $scope.modelId = $routeParams.modelId;
 
@@ -34,7 +34,9 @@ repositoryControllers.controller("MappingBuilderController", ["$rootScope","$uib
 
     $scope.htmlPopover = $sce.trustAsHtml(
     "<p>Use your custom converters in your mapping rules, e.g. custom:myfunc()</p>");
-    
+
+    sessionTimeoutService.initSessionTimeoutWarning($scope);
+
     $scope.setAceLang = function() {
     	if ($scope.contentType === 'json') {
     		$scope.sourceEditorSession.setMode("ace/mode/json");

--- a/repository/repository-web/dist/js/init/appServiceLoader.js
+++ b/repository/repository-web/dist/js/init/appServiceLoader.js
@@ -2,7 +2,8 @@ define([
   '../service/commonDialogServices',
   '../service/modelCreationService',
   '../service/modelDetailsService',
-  '../service/tenantService'
+  '../service/tenantService',
+  '../service/sessionTimeoutService'
 ], function () {
 
 });

--- a/repository/repository-web/dist/js/service/sessionTimeoutService.js
+++ b/repository/repository-web/dist/js/service/sessionTimeoutService.js
@@ -1,0 +1,78 @@
+define(["../init/appService"], function(repository) {
+  var timeout = 30000;
+  repository.factory('SessionTimeoutService',['$rootScope', '$http','$q','$location', '$timeout', function($rootScope, $http, $q, $location, $timeout) {
+    return {
+      initSessionTimeoutWarning: initSessionTimeoutWarning,
+      extendSession: extendSession,
+      checkSessionTimeout: checkSessionTimeout
+    };
+
+    function initSessionTimeoutWarning($scope) {
+      $scope.logout = $rootScope.logout;
+      $scope.extendSession = function() {
+        extendSession($scope);
+      };
+      checkSessionTimeout($scope);
+    }
+
+    function extendSession($scope) {
+      $http.get('./rest/accounts/' + $rootScope.user)
+        .error(function (result) {
+          $rootScope.logout();
+        });
+      checkSessionTimeout($scope);
+    }
+
+    function checkSessionTimeout($scope) {
+      $http.get('rest/config/session/timeout')
+        .then(function(result) {
+          var timeoutOffset;
+          if ((result.data * 1000) > 300000) {
+            timeoutOffset = 300000;
+          } else {
+            timeoutOffset = (result.data * 1000) / 2;
+          }
+          timeout = result.data * 1000 - timeoutOffset; // seconds to milliseconds
+          $scope.sessionExpirationWarning = false;
+          $scope.sessionExpirationPromise = $timeout(function() {
+            return $rootScope.authenticated; // only display warning if the user is authenticated
+          }, timeout);
+          $scope.sessionExpirationPromise.then(function(value) {
+            $scope.sessionExpirationWarning = value;
+            countDown($scope, timeoutOffset)
+          });
+        });
+    }
+
+    function countDown($scope, timeoutOffset) {
+      $scope.sessionTimeoutCountdown = timeoutOffset / 1000;
+      $scope.sessionTimeoutCountdownStep = function() {
+        $scope.sessionTimeoutCountdown = $scope.sessionTimeoutCountdown - 1;
+        $scope.sessionTimeoutDisplayValue = buildDisplayString($scope);
+        countdown = $timeout($scope.sessionTimeoutCountdownStep, 1000);
+        if ($scope.sessionTimeoutCountdown <= 0) {
+          $timeout.cancel(countdown);
+        }
+      };
+      var countdown = $timeout($scope.sessionTimeoutCountdownStep, 1000);
+    }
+
+    function buildDisplayString($scope) {
+      var minutes = Math.floor($scope.sessionTimeoutCountdown / 60);
+      var seconds = ($scope.sessionTimeoutCountdown % 60).toFixed(0);
+      var minuteLabel;
+      if (minutes == 1) {
+        minuteLabel = " minute ";
+      } else {
+        minuteLabel = " minutes ";
+      }
+      var secondLabel;
+      if (seconds == 1) {
+        secondLabel = " second";
+      } else {
+        secondLabel = " seconds";
+      }
+      return minutes + minuteLabel + seconds + secondLabel;
+    }
+  }]);
+});

--- a/repository/repository-web/dist/partials/details-template.html
+++ b/repository/repository-web/dist/partials/details-template.html
@@ -1,3 +1,4 @@
+<ng-include src="'webjars/repository-web/dist/partials/templates/session-timeout-warning.html'"></ng-include>
 <div ng-if="errorLoading" class="row">
 		<div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {{errorLoading}}</div>
 </div>

--- a/repository/repository-web/dist/partials/mapping/mappingcreator.html
+++ b/repository/repository-web/dist/partials/mapping/mappingcreator.html
@@ -1,3 +1,4 @@
+<ng-include src="'webjars/repository-web/dist/partials/templates/session-timeout-warning.html'"></ng-include>
 <!-- Main content -->
 <section class="content" id="mapping">
    <ol class="breadcrumb">

--- a/repository/repository-web/dist/partials/templates/session-timeout-warning.html
+++ b/repository/repository-web/dist/partials/templates/session-timeout-warning.html
@@ -1,0 +1,14 @@
+<div ng-show="sessionExpirationWarning" class="alert alert-danger alert-danger-stick-top">
+  <div ng-if="sessionTimeoutCountdown > 0">
+    <p>
+      <i class="fa fa-fw fa-exclamation-triangle"></i>Warning - your session expires in {{sessionTimeoutDisplayValue}}.
+    </p>
+    <button ng-click="extendSession()" class="btn btn-primary pull-center">Extend session</button>
+  </div>
+  <div ng-if="sessionTimeoutCountdown == 0">
+    <p>
+      <i class="fa fa-fw fa-exclamation-triangle"></i>Warning - your session has expired. Please save your work and login again.
+    </p>
+    <button ng-click="logout()" class="btn btn-primary pull-center">Logout</button>
+  </div>
+</div>


### PR DESCRIPTION
To introduce the session timeout warning, I have created a new REST endpoint on the backend that simply returns the HTTP session timeout. 

In the frontend, I have created a new AngularJS service (SessionTimeoutService) that retrieves the configured timeout from the backend and sets a timeout until the warning will be displayed. 

The HTML for the warning is in a separate file that can be included wherever needed. For now it's included in the details and mapping pages. The new CSS class .alert-danger-stick-top sticks the warning to the top of the viewport, so it will always be displayed, no matter where the user scrolled. 

5 minutes before the session expires, the warning will be displayed with a countdown and a button to extend the session. When the session is expired, a message will be displayed with a button to complete the logout in the frontend. 

Signed-off-by: kolotu <kevin.olotu@bosch-si.com>