### PR TITLE
enhancement/2132 Integration Tests for Elastic Search functionality i…

### DIFF
--- a/repository/repository-elasticsearch/pom.xml
+++ b/repository/repository-elasticsearch/pom.xml
@@ -1,32 +1,97 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.eclipse.vorto</groupId>
-		<artifactId>repository</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>repository-elasticsearch</artifactId>
-	<packaging>jar</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.vorto</groupId>
+    <artifactId>repository</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>repository-elasticsearch</artifactId>
+  <packaging>jar</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.vorto</groupId>
-			<artifactId>repository-core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		 <!-- Elastic search indexing service (start) -->
-        <dependency>
-		    <groupId>org.elasticsearch</groupId>
-		    <artifactId>elasticsearch</artifactId>
-			<version>6.7.2</version>
-		</dependency>
-        
-        <dependency>
-		    <groupId>org.elasticsearch.client</groupId>
-		    <artifactId>elasticsearch-rest-high-level-client</artifactId>
-		    <version>6.7.2</version>
-		</dependency>
-		<!-- Elastic search indexing service (end) -->
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.vorto</groupId>
+      <artifactId>repository-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>6.7.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <version>6.7.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Spins up an ElasticSearch server at runtime, for tests -->
+    <dependency>
+      <groupId>pl.allegro.tech</groupId>
+      <artifactId>embedded-elasticsearch</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+    Required by Allegro above, due to some signature usage incompatible with 2.2 (currently in
+    use in the parent.
+     -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Required by ES spin up by Allegro -->
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <version>7.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Required to import models in tests -->
+      <plugin>
+        <groupId>org.eclipse.xtend</groupId>
+        <artifactId>xtend-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/AllSearchTests.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/AllSearchTests.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({GeneralSearchTest.class, MixedSearchTest.class,
+    NameSearchSimpleTest.class,
+    AuthorSearchSimpleTest.class,
+    UserReferenceSearchSimpleTest.class, TypeSearchSimpleTest.class, StateSearchSimpleTest.class,
+    NamespaceSearchSimpleTest.class, VersionSearchSimpleTest.class})
+public class AllSearchTests {
+
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/AuthorSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/AuthorSearchSimpleTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests author-based tagged searches.<br/>
+ *
+ * @author mena-bosch
+ */
+public class AuthorSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL, testInfrastructure.getDefaultUser());
+    // "control group": importing another model as another user
+    testInfrastructure.importModel("HueLightStrips.infomodel",
+        testInfrastructure.createUserContext("erle", "playground"));
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  /**
+   * Tests that the extraneous model that is never referenced in other author searches is, in fact,
+   * returned when the query is broad enough.
+   */
+  @Test
+  public void testControlGroup() {
+    String query = "author:alex author:*";
+    assertEquals(2,
+        testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser())
+            .size());
+  }
+
+  /**
+   * Note: all models seem to have {@literal alex} as author.
+   */
+  @Test
+  public void testSimpleAuthor() {
+    String query = "author:alex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleAuthorCaseInsensitive() {
+    String query = "author:ALEX";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return 0 model - author incomplete
+   */
+  @Test
+  public void testSimpleAuthorIncomplete() {
+    String query = "author:ale";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardAuthor() {
+    String query = "author:*lex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardAuthor() {
+    String query = "author:ale*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardAuthor() {
+    String query = "author:a*ex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardAuthorCaseInsensitive() {
+    String query = "author:ALE*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardAuthor() {
+    String query = "author:?lex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardAuthor() {
+    String query = "author:ale?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardAuthor() {
+    String query = "author:al?x";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardAuthorCaseInsensitive() {
+    String query = "author:A?EX";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardAuthor() {
+    String query = "author:*l?x";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardAuthor() {
+    String query = "author:?le*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/GeneralSearchTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/GeneralSearchTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Ported from original ModelRepositorySearchTest
+ */
+public class GeneralSearchTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+    ModelInfo datatype = testInfrastructure.importModel("Color.type", testInfrastructure.getDefaultUser());
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testSearchWithNull() {
+    assertEquals(1, testInfrastructure.getSearchService().search(null, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testSearchWithEmptyExpression() {
+    assertEquals(1, testInfrastructure.getSearchService().search("", testInfrastructure.getDefaultUser()).size());
+  }
+
+  /**
+   * Note: originally  in the JRC tests, the garbage query string was: {@literal !$@}. <br/>
+   * That was correctly not returning any model with JCR queries.<br/>
+   * However since this is an un-tagged query, it will be interpreted as an ElasticSearch
+   * query string. <br/>
+   * The edge case here is the {@literal !} starting character, which is a reserved character.<br/>
+   * While the documentation is not entirely clear on the matter, I suspect this may negate the
+   * following characters, which in turn would return any model whose name does not contain
+   * {@literal $} or {@literal @}, i.e. in our case (and likely all cases), any model.
+   */
+  @Test
+  public void testSearchWithSpecialCharacter() {
+    assertEquals(0, testInfrastructure.getSearchService().search("$@!", testInfrastructure.getDefaultUser()).size());
+  }
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/MixedSearchTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/MixedSearchTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Ported from original ModelRepositorySearchTest. <br/> This includes tests ranging across
+ * different tags / filters.
+ */
+public class MixedSearchTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+    testInfrastructure.importModel("Color.type", testInfrastructure.getDefaultUser());
+    testInfrastructure.importModel("Colorlight.fbmodel", testInfrastructure.getDefaultUser());
+    testInfrastructure.importModel("Switcher.fbmodel", testInfrastructure.getDefaultUser());
+    testInfrastructure.importModel("HueLightStrips.infomodel", testInfrastructure.getDefaultUser());
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testMultipleTermsNotRepeated() {
+    String query = "version:1.0* color";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(2, model.size());
+  }
+
+  /**
+   * The two name expressions catch all names starting with c and al names ending with r, which
+   * returns <b>C</b>olor, <b>C</b>olorLight but also Switche<b>r</b>.<br/> The version is the same
+   * for all.<br/> The type is repeated and includes both types of the above models: datatype and
+   * functionblock.<br/> Finally some repetition over patterns for author and userReference include
+   * the default author / lastModifiedBy, i.e. {@literal alex}, alongside some negative noise
+   * ({@literal nobody)}.<br/> Bottomline, this is supposed to return 3 models: {@literal
+   * Color.type}, {@literal Colorlight.fbmodel} and {@literal Switcher.fbmodel}, but <b>not</b>
+   * {@literal HueLightStrips.infomodel}.<br/> The reason why the latter is not included in the
+   * result, despite the all-inclusive {@literal userReference:*}, is because <i>different</i> tags
+   * are {@code AND}-related (while conversely, same, repeated tags are {@code OR}-related).<br/>
+   * Worth reminding, {@literal userReference} aggregates {@literal author} and {@literal
+   * lastModifiedBy} in an {@code OR} condition - yet in this case, the explicit {@literal author}
+   * tag is handled separately.
+   */
+  @Test
+  public void testMultipleTermsSomeRepeated() {
+    String query = "version:1.0* c* *r type:data* type:function* author:alex author:?LE? author:NOBODY userReference:* userReference:nobody";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+  }
+
+  @Test
+  public void testSearchAllModelsWithWildCard() {
+    assertEquals(4, testInfrastructure.getSearchService().search("*", testInfrastructure.getDefaultUser()).size());
+    // references not fetched contextually to ES
+  }
+
+  @Test
+  public void testSearchByFreetextLeadingCaseInsensitive() {
+    assertEquals(2,
+        testInfrastructure.getSearchService().search("color", testInfrastructure.getDefaultUser()).size());
+  }
+
+  /**
+   * This test uses free text to search for a model name but provides no wildcard. <br/> As such,
+   * while a trailing multi-wildcard is automatically added, no leading wildcard is. <br/> Given the
+   * term does not appear at the start of either model containing it, no model is fetched.
+   */
+  @Test
+  public void testSearchByFreetextTrailingCaseInsensitive() {
+    assertEquals(0,
+        testInfrastructure.getSearchService().search("light", testInfrastructure.getDefaultUser()).size());
+  }
+
+  /*
+   * Surrounding search term in wildcards so the one model name containing the sequence is
+   * returned.
+   */
+  @Test
+  public void testSearchByFreetextMiddleWildcardsSurrounding() {
+    assertEquals(1, testInfrastructure.getSearchService().search("*tch*", testInfrastructure.getDefaultUser()).size());
+  }
+
+  /*
+   * Wildcard trailing but no model name starting with sequence and wildcard leading is <b>not</b>
+   * implied by search.
+   */
+  @Test
+  public void testSearchByFreetextTrailingWildCard() {
+    assertEquals(0, testInfrastructure.getSearchService().search("tch*", testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testSearchModelByModelName() {
+    assertEquals(2, testInfrastructure.getSearchService().search("name:Color", testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testSearchModelByNameWildcard() {
+    assertEquals(2, testInfrastructure.getSearchService().search("name:Color*", testInfrastructure.getDefaultUser()).size());
+  }
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/NameSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/NameSearchSimpleTest.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests name-based searches, with or without tags.<br/> The unit tests here are trivial, and follow
+ * a schema common to all search fields. <br/>
+ *
+ * @author mena-bosch
+ */
+public class NameSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+    testInfrastructure.importModel("Color.type");
+    // "control group": extraneous model that should never appear in search
+    testInfrastructure.importModel("HueLightStrips.infomodel");
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  /**
+   * Tests that the extraneous model that is never referenced in other name searches is, in fact,
+   * returned when the query is broad enough.
+   */
+  @Test
+  public void testControlGroup() {
+    String query = "name:Color name:*";
+    assertEquals(2, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testSimpleName() {
+    String query = "Color";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleNameCaseInsensitive() {
+    String query = "color";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return the relevant model anyway, as name terms without wildcards are appended a
+   * multi-character wildcard automatically at back-end level.
+   */
+  @Test
+  public void testSimpleNameIncompleteTrailing() {
+    String query = "col";
+    assertEquals(1, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  /**
+   * Expected to return 0 model - name incomplete. Note that a wildcard is applied automatically at
+   * the end (for backwards-compatibility), but not at the beginning, and for names only.
+   */
+  @Test
+  public void testSimpleNameIncompleteLeading() {
+    String query = "olor";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardName() {
+    String query = "*olor";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardName() {
+    String query = "Colo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardName() {
+    String query = "Co*or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardNameCaseInsensitive() {
+    String query = "colo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardName() {
+    String query = "?olor";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardName() {
+    String query = "Colo?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardName() {
+    String query = "Co?or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardNameCaseInsensitive() {
+    String query = "co?or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardName() {
+    String query = "*lo?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardName() {
+    String query = "?olo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleNameTagged() {
+    String query = "name:Color";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleNameCaseInsensitiveTagged() {
+    String query = "name:color";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleNameIncompleteTagged() {
+    String query = "name:Colo";
+    assertEquals(1, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardNameTagged() {
+    String query = "name:*olor";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardNameTagged() {
+    String query = "name:Colo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardNameTagged() {
+    String query = "name:Co*or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardNameCaseInsensitiveTagged() {
+    String query = "name:colo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardNameTagged() {
+    String query = "name:?olor";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardNameTagged() {
+    String query = "name:Colo?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardNameTagged() {
+    String query = "name:Co?or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardNameCaseInsensitiveTagged() {
+    String query = "name:co?or";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardNameTagged() {
+    String query = "name:*lo?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardNameTagged() {
+    String query = "name:?olo*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/StateSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/StateSearchSimpleTest.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.eclipse.vorto.repository.workflow.ModelState;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests model state based tagged searches.<br/> Note that not all types are tested against all
+ * possible case and wildcard scenarios here, to keep the number of tests reasonable.
+ *
+ * @author mena-bosch
+ */
+public class StateSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  private static void updateState(ModelInfo model, String state) {
+    testInfrastructure.getRepositoryFactory().getRepository(testInfrastructure.getDefaultUser())
+        .updateState(model.getId(), state);
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+
+    testInfrastructure = new SearchTestInfrastructure();
+
+    // will apply state updates after importing models
+    // draft
+    testInfrastructure.importModel(testInfrastructure.FUNCTIONBLOCK_MODEL, testInfrastructure.getDefaultUser());
+    // in review
+    testInfrastructure.importModel(testInfrastructure.INFORMATION_MODEL, testInfrastructure.getDefaultUser());
+    // released
+    testInfrastructure.importModel(testInfrastructure.MAPPING_MODEL, testInfrastructure.getDefaultUser());
+    // deprecated
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL, testInfrastructure.getDefaultUser());
+
+    List<ModelInfo> model = testInfrastructure.getRepositoryFactory().getRepository(testInfrastructure.getDefaultUser()).search("*");
+    // this is arguably over-cautious, as the next statement would fail all tests anyway
+    if (model.isEmpty()) {
+      fail("Model is empty after importing.");
+    }
+    // state updates here
+    model.forEach(
+        mi -> {
+          switch (mi.getType()) {
+            case Functionblock: {
+              updateState(mi, "Draft");
+              break;
+            }
+            case InformationModel: {
+              updateState(mi, "InReview");
+              break;
+            }
+            case Mapping: {
+              updateState(mi, "Released");
+              break;
+            }
+            case Datatype: {
+              updateState(mi, "Deprecated");
+              break;
+            }
+          }
+        }
+    );
+    /*
+    This is very ugly but necessary. The time it takes for the whole event-based cycle to occur when
+    updating model states is smaller than the time between @AfterClass finalizes and tests start.
+    There is no point in invoking reindex as Elasticsearch is already processing the reindex requests
+    for each model - in fact it might very well fail.
+    This is not necessary in the repository-core tests because the indexing service is mocked and
+    does not depend on a third-party service like the Elasticsearch runtime spun by SearchTestInfrastructure.
+     */
+    try {
+      Thread.sleep(1000);
+    }
+    // swallowing here on purpose
+    catch (InterruptedException ie) {}
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testNoModel() {
+    String query = "state:*potato?*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(0, model.size());
+  }
+
+  @Test
+  public void testPlainDraftState() {
+    String query = "state:Draft";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Draft.getName());
+  }
+
+  @Test
+  public void testPlainDraftStateCaseInsensitive() {
+    String query = "state:dRAFT";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Draft.getName());
+  }
+
+  @Test
+  public void testDraftStateWithWildcards() {
+    String query = "state:?R*t";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Draft.getName());
+  }
+
+  @Test
+  public void testPlainInReviewState() {
+    String query = "state:InReview";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.InReview.getName());
+  }
+
+  @Test
+  public void testPlainInReviewStateCaseInsensitive() {
+    String query = "state:iNrEVIEW";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.InReview.getName());
+  }
+
+  @Test
+  public void testInReviewStateWithWildcards() {
+    String query = "state:?Nr*i?w";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.InReview.getName());
+  }
+
+  @Test
+  public void testPlainReleasedState() {
+    String query = "state:Released";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Released.getName());
+  }
+
+  @Test
+  public void testPlainReleasedStateCaseInsensitive() {
+    String query = "state:rELEASED";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Released.getName());
+  }
+
+  @Test
+  public void testReleasedStateWithWildcards() {
+    String query = "state:*l?as*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Released.getName());
+  }
+
+  @Test
+  public void testPlainDeprecatedState() {
+    String query = "state:Deprecated";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Deprecated.getName());
+  }
+
+  @Test
+  public void testPlainDeprecatedStateCaseInsensitive() {
+    String query = "state:dEPRECATED";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Deprecated.getName());
+  }
+
+  @Test
+  public void testDeprecatedStateWithWildcards() {
+    String query = "state:*p?ECaT*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(model.get(0).getState(), ModelState.Deprecated.getName());
+  }
+
+  /**
+   * Uses a wildcard expression broad enough to match three states.
+   */
+  @Test
+  public void testThreeStatesWithBroadWildcard() {
+    String query = "state:*RE*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+  }
+
+  /**
+   * Some garbage query with repetitions of tags, wildcards all over, etc. Should match 3 states.
+   */
+  @Test
+  public void testMultipleTagsRepeatedValuesSomeWildcards() {
+    String query = "state:dr* state:*aft state:depre?ated state:?nr*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+  }
+
+
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/TypeSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/TypeSearchSimpleTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests model type based tagged searches.<br/> Note that not all types are tested against all
+ * possible case and wildcard scenarios here, to keep the number of tests reasonable.
+ *
+ * @author mena-bosch
+ */
+public class TypeSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+
+    // importing one model for each supported type here
+    // function block
+    testInfrastructure.importModel(testInfrastructure.FUNCTIONBLOCK_MODEL);
+
+    // info model
+    testInfrastructure.importModel(testInfrastructure.INFORMATION_MODEL);
+
+    // data type
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL);
+
+    // mapping
+    testInfrastructure.importModel(testInfrastructure.MAPPING_MODEL);
+
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testNoModel() {
+    String query = "type:*potato?*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(0, model.size());
+  }
+
+  @Test
+  public void testPlainFunctionblock() {
+    String query = "type:Functionblock";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.FUNCTIONBLOCK_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainFunctionblockCaseInsensitive() {
+    String query = "type:fUNCTIONBLOCK";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.FUNCTIONBLOCK_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainInfomodel() {
+    String query = "type:InformationModel";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainInfomodelCaseInsensitive() {
+    String query = "type:iNFORMATIONmODEL";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * The query here is so ambiguous that it should catch both infomodel and functionblock.
+   */
+  @Test
+  public void testTwoModelsCaseInsensitive() {
+    String query = "type:*ON*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(2, model.size());
+    assertTrue(model.stream().map(SearchTestInfrastructure::getFileName).allMatch(
+        s -> s.equals(testInfrastructure.INFORMATION_MODEL) || s
+            .equals(testInfrastructure.FUNCTIONBLOCK_MODEL)));
+  }
+
+  @Test
+  public void testPlainDatatype() {
+    String query = "type:Datatype";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainDatatypeCaseInsensitive() {
+    String query = "type:dATATYPE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainMapping() {
+    String query = "type:Mapping";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.MAPPING_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainMappingCaseInsensitive() {
+    String query = "type:mAPPING";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.MAPPING_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testAllTypesWithSingleWildcard() {
+    String query = "type:*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(4, model.size());
+  }
+
+  @Test
+  public void testThreeTypesWithWildcardsAndRepeatedTagCaseInsensitive() {
+    String query = "type:m* type:?ATA*e type:?nf????tioNm*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+    assertTrue(model.stream().map(SearchTestInfrastructure::getFileName)
+        .noneMatch(s -> s.equals(testInfrastructure.FUNCTIONBLOCK_MODEL)));
+  }
+
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/UserReferenceSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/UserReferenceSearchSimpleTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import org.eclipse.vorto.model.ModelId;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests user reference-based tagged searches, which search for both {@literal author} and {@literal
+ * lastModifiedBy} fields under the hood. <br/> Note that not all types are tested against all
+ * possible case and wildcard scenarios here, to keep the number of tests reasonable.
+ *
+ * @author mena-bosch
+ */
+public class UserReferenceSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+  static IUserContext erleContext;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testInfrastructure = new SearchTestInfrastructure();
+    erleContext = testInfrastructure.createUserContext("erle");
+
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL);
+    List<ModelInfo> model = testInfrastructure.getRepositoryFactory()
+        .getRepository(testInfrastructure.getDefaultUser()).search("*");
+    // this is arguably over-cautious, as the next statement would fail all tests anyway
+    if (model.isEmpty()) {
+      fail("Model is empty after importing.");
+    }
+    // "reviewer" user updates the only imported model's visibility to public, i.e.
+    // "lastModifiedBy" -> reviewer
+    model.get(0).setLastModifiedBy("reviewer");
+    ModelId updated = testInfrastructure.getRepositoryFactory().getRepository(testInfrastructure.createUserContext("reviewer"))
+        .updateVisibility(model.get(0).getId(), "Public");
+
+    // "control group": importing another model as another user
+    testInfrastructure.importModel("HueLightStrips.infomodel", erleContext);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  /**
+   * Tests that the extraneous model that is never referenced in other user reference searches is,
+   * in fact, returned when the query is broad enough.
+   */
+  @Test
+  public void testControlGroup() {
+    String query = "userReference:alex userReference:reviewer userReference:*";
+    assertEquals(2, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testSimpleUserReferenceByAuthor() {
+    String query = "userReference:alex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleUserReferenceCaseInsensitiveByAuthor() {
+    String query = "userReference:ALEX";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return 0 model - user reference incomplete
+   */
+  @Test
+  public void testSimpleUserReferenceIncompleteByAuthor() {
+    String query = "userReference:ale";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardUserReferenceByAuthor() {
+    String query = "userReference:*lex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardUserReferenceByAuthor() {
+    String query = "userReference:ale*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardUserReferenceByAuthor() {
+    String query = "userReference:a*ex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardUserReferenceCaseInsensitiveByAuthor() {
+    String query = "userReference:ALE*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardUserReferenceByAuthor() {
+    String query = "userReference:?lex";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardUserReferenceByAuthor() {
+    String query = "userReference:ale?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardUserReferenceByAuthor() {
+    String query = "userReference:al?x";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardUserReferenceCaseInsensitiveByAuthor() {
+    String query = "userReference:A?EX";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardUserReferenceByAuthor() {
+    String query = "userReference:*l?x";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardUserReferenceByAuthor() {
+    String query = "userReference:?le*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleUserReferenceByLastModifier() {
+    String query = "userReference:reviewer";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testSimpleUserReferenceCaseInsensitiveByLastModifier() {
+    String query = "userReference:REVIEWER";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return 0 model - user reference incomplete
+   */
+  @Test
+  public void testSimpleUserReferenceIncompleteByLastModifier() {
+    String query = "userReference:review";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardUserReferenceByLastModifier() {
+    String query = "userReference:*viewer";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardUserReferenceByLastModifier() {
+    String query = "userReference:review*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardUserReferenceByLastModifier() {
+    String query = "userReference:r*iewer";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardUserReferenceCaseInsensitiveByLastModifier() {
+    String query = "userReference:REVIEW*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardUserReferenceByLastModifier() {
+    String query = "userReference:?eviewer";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardUserReferenceByLastModifier() {
+    String query = "userReference:reviewe?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardUserReferenceByLastModifier() {
+    String query = "userReference:revie?er";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardUserReferenceCaseInsensitiveByLastModifier() {
+    String query = "userReference:R?VIEWER";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardUserReferenceByLastModifier() {
+    String query = "userReference:*v?ewer";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardUserReferenceByLastModifier() {
+    String query = "userReference:?eview*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/VersionSearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/VersionSearchSimpleTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import org.eclipse.vorto.repository.core.IModelRepository;
+import org.eclipse.vorto.repository.core.IUserContext;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests model version based tagged searches.<br/>
+ *
+ * @author mena-bosch
+ */
+public class VersionSearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+
+    testInfrastructure = new SearchTestInfrastructure();
+
+    // Color type with version 1.0.0 - will update to 1.0.1
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL, testInfrastructure.getDefaultUser());
+
+    // Switcher fb with version 1.0.0 - will update to 2.1.0
+    testInfrastructure.importModel(testInfrastructure.FUNCTIONBLOCK_MODEL, testInfrastructure.getDefaultUser());
+
+    List<ModelInfo> model = testInfrastructure.getRepositoryFactory()
+        .getRepository(testInfrastructure.getDefaultUser()).search("*");
+    // this is arguably over-cautious, as the next statement would fail all tests anyway
+    if (model.isEmpty()) {
+      fail("Model is empty after importing.");
+    }
+    IModelRepository repo = testInfrastructure.getRepositoryFactory().getRepository(testInfrastructure.getDefaultUser());
+    ModelInfo type = model.stream()
+        .filter(m -> m.getFileName().equals(testInfrastructure.DATATYPE_MODEL)).findFirst()
+        .orElseGet(() -> {
+          fail("Model not found");
+          return null;
+        });
+    ModelInfo functionBlock = model.stream()
+        .filter(m -> m.getFileName().equals(testInfrastructure.FUNCTIONBLOCK_MODEL)).findFirst()
+        .orElseGet(() -> {
+          fail("Model not found");
+          return null;
+        });
+    // updating infomodel to 1.0.1 and removing previous
+    repo.createVersion(type.getId(), "1.0.1", testInfrastructure.getDefaultUser());
+    repo.removeModel(type.getId());
+    // updating functionblock to 2.1.0 and removing previous
+    repo.createVersion(functionBlock.getId(), "2.1.0", testInfrastructure.getDefaultUser());
+    repo.removeModel(functionBlock.getId());
+    // finally, importing mapping as-is (1.0.0)
+    testInfrastructure.importModel(testInfrastructure.MAPPING_MODEL);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testNoModel() {
+    String query = "version:*potato*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(0, model.size());
+  }
+
+  @Test
+  public void testNoModelWithValidVersion() {
+    String query = "version:1.1.1";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(0, model.size());
+  }
+
+  @Test
+  public void testPlainVersion() {
+    String query = "version:1.0.1";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardVersion() {
+    String query = "version:*.0.1";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+  }
+
+  /**
+   * This will fetch both v. 1.0.1 and v. 1.0.0 models
+   */
+  @Test
+  public void testTrailingMultiWildcardVersion() {
+    String query = "version:1.0.*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(2, model.size());
+  }
+
+  /**
+   * This will fetch both models whose version ends in 0
+   */
+  @Test
+  public void testBroaderMultiWildcardVersion() {
+    String query = "version:*0";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(2, model.size());
+  }
+
+  @Test
+  public void testTrailingSingleWildcardsVersion() {
+    String query = "version:2.?.*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.FUNCTIONBLOCK_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * This will fetch both models whose version starts with 1.0
+   */
+  @Test
+  public void testSingleWildcardVersion() {
+    String query = "version:1.0.?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(2, model.size());
+  }
+
+  /**
+   * Wildcard is broad enough to fetch all model
+   */
+  @Test
+  public void testBroadWildcardsVersion() {
+    String query = "version:*.?.?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+  }
+
+  /**
+   * This (silly) query is a catch-all. The multi-wildcard implies 0+ occurrences of any character,
+   * meaning *0* also fetches models whose version ends in 0, etc.
+   */
+  @Test
+  public void testWildcardsAndMultipleTagsVersions() {
+    String query = "version:2* version:*0* version:*1*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(3, model.size());
+  }
+}

--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/VisibilitySearchSimpleTest.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/VisibilitySearchSimpleTest.java
@@ -1,0 +1,366 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional information regarding copyright
+ * ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.vorto.repository.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import org.eclipse.vorto.model.ModelId;
+import org.eclipse.vorto.repository.core.ModelInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests visibility-based tagged searches.<br/>
+ *
+ * @author mena-bosch
+ */
+public class VisibilitySearchSimpleTest {
+
+  static SearchTestInfrastructure testInfrastructure;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    
+    testInfrastructure = new SearchTestInfrastructure();
+    
+    testInfrastructure.importModel(testInfrastructure.DATATYPE_MODEL);
+    List<ModelInfo> model = testInfrastructure.getRepositoryFactory()
+        .getRepository(testInfrastructure.createUserContext("alex")).search("*");
+    // this is arguably over-cautious, as the next statement would fail all tests anyway
+    if (model.isEmpty()) {
+      fail("Model is empty after importing.");
+    }
+    // "alex" user updates the only imported model's visibility to public
+    ModelId updated = testInfrastructure.getRepositoryFactory()
+        .getRepository(testInfrastructure.createUserContext("alex"))
+        .updateVisibility(model.get(0).getId(), "Public");
+
+    // importing another model as private
+    testInfrastructure.importModel(testInfrastructure.INFORMATION_MODEL,
+        testInfrastructure.createUserContext("alex", "playground"));
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    testInfrastructure.terminate();
+  }
+
+  @Test
+  public void testPlainVisibilityPublic() {
+    String query = "visibility:Public";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainVisibilityPublicCaseInsensitive() {
+    String query = "visibility:pUBLIC";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return 0 model - value incomplete
+   */
+  @Test
+  public void testVisibilityPublicIncomplete() {
+    String query = "visibility:Pub";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardVisibilityPublic() {
+    String query = "visibility:*blic";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingMultiWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:*BLIC";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardVisibilityPublic() {
+    String query = "visibility:?ublic";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:?UBLIC";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardVisibilityPublic() {
+    String query = "visibility:Publ*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:PUBL*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardVisibilityPublic() {
+    String query = "visibility:Publi?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:pUBLI?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardVisibilityPublic() {
+    String query = "visibility:Pu*c";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:pU*C";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardVisibilityPublic() {
+    String query = "visibility:Pu?lic";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:pU?LIC";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardVisibilityPublic() {
+    String query = "visibility:*u?lic";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:*U?LIC";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardVisibilityPublic() {
+    String query = "visibility:P?bl*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardVisibilityPublicCaseInsensitive() {
+    String query = "visibility:p?BL*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.DATATYPE_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainVisibilityPrivate() {
+    String query = "visibility:Private";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testPlainVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:pRIVATE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  /**
+   * Expected to return 0 model - value incomplete
+   */
+  @Test
+  public void testVisibilityPrivateIncomplete() {
+    String query = "visibility:Pri";
+    assertEquals(0, testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser()).size());
+  }
+
+  @Test
+  public void testLeadingMultiWildcardVisibilityPrivate() {
+    String query = "visibility:*vate";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingMultiWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:*VATE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardVisibilityPrivate() {
+    String query = "visibility:?rivate";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testLeadingSingleWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:?RIVATE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardVisibilityPrivate() {
+    String query = "visibility:Priv*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingMultiWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:pRIV*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardVisibilityPrivate() {
+    String query = "visibility:Privat?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testTrailingSingleWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:pRIVAT?";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardVisibilityPrivate() {
+    String query = "visibility:Pr*e";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleMultiWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:pR*E";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardVisibilityPrivate() {
+    String query = "visibility:Pr?vate";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMiddleSingleWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:pR?VATE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardVisibilityPrivate() {
+    String query = "visibility:*r?vate";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiLeadingWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:*R?VATE";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardVisibilityPrivate() {
+    String query = "visibility:P?iva*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+  @Test
+  public void testMixedMultiTrailingWildcardVisibilityPrivateCaseInsensitive() {
+    String query = "visibility:p?IV*";
+    List<ModelInfo> model = testInfrastructure.getSearchService().search(query, testInfrastructure.getDefaultUser());
+    assertEquals(1, model.size());
+    assertEquals(testInfrastructure.INFORMATION_MODEL, SearchTestInfrastructure.getFileName(model.get(0)));
+  }
+
+}

--- a/repository/repository-elasticsearch/src/test/resources/logback.xml
+++ b/repository/repository-elasticsearch/src/test/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<logger name="org.modeshape" level="info" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<logger name="org.eclipse.vorto" level="info" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<logger name="org.jgroups" level="info" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<root level="error">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/Color.type
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/Color.type
@@ -1,0 +1,8 @@
+vortolang 1.0
+
+namespace org.eclipse.vorto.examples.type
+version 1.0.0
+
+entity Color {
+	mandatory color as string
+}

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/ColorLightIM.infomodel
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/ColorLightIM.infomodel
@@ -1,0 +1,15 @@
+vortolang 1.0
+
+namespace com.mycompany
+version 1.0.0
+displayname "ColorLight IM"
+description "Information model for Color Light IM"
+category demo
+using org.eclipse.vorto.examples.fb.ColorLight ; 1.0.0
+
+infomodel ColorLightIM {
+	
+	functionblocks {
+		colorLight as ColorLight
+	}
+}

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/Color_ios.mapping
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/Color_ios.mapping
@@ -1,0 +1,11 @@
+vortolang 1.0
+
+namespace org.eclipse.vorto.examples.type
+version 1.0.0
+displayname "color ios mapping"
+description "color to ios mapping"
+using org.eclipse.vorto.examples.type.Color;1.0.0
+entitymapping Color_ios {
+	targetplatform ios
+	from Color.name to colortype
+}	

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/Colorlight.fbmodel
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/Colorlight.fbmodel
@@ -1,0 +1,15 @@
+vortolang 1.0
+
+namespace org.eclipse.vorto.examples.fb
+version 1.0.0
+displayname "ColorLight"
+description "Function block model for ColorLight"
+category demo
+using org.eclipse.vorto.examples.type.Color ; 1.0.0
+functionblock ColorLight {
+	
+	operations {
+		setColor(color as Color)
+	}
+
+}

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/HueLightStrips.infomodel
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/HueLightStrips.infomodel
@@ -1,0 +1,15 @@
+vortolang 1.0
+
+namespace com.mycompany
+version 1.0.0
+displayname "HueLightStrips"
+description "Information model for HueLightStrips"
+category demo
+using com.mycompany.fb.Switcher ; 1.0.0
+
+infomodel HueLightStrips {
+	
+	functionblocks {
+		switcher as Switcher
+	}
+}

--- a/repository/repository-elasticsearch/src/test/resources/sample_models/Switcher.fbmodel
+++ b/repository/repository-elasticsearch/src/test/resources/sample_models/Switcher.fbmodel
@@ -1,0 +1,16 @@
+vortolang 1.0
+
+namespace com.mycompany.fb
+version 1.0.0
+displayname "Switcher"
+description "Switcher switches a device on or off"
+category demo
+functionblock Switcher {
+	
+	operations {
+		on()
+		off()
+		toggle()
+	}
+
+}

--- a/repository/repository-elasticsearch/src/test/resources/vorto-repository.json
+++ b/repository/repository-elasticsearch/src/test/resources/vorto-repository.json
@@ -1,0 +1,31 @@
+{
+    "name" : "vorto",
+    "workspaces" : {
+        "default" : "playground",
+        "allowCreation" : true
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            {
+                "name" : "Spring Security",
+                "classname" : "org.eclipse.vorto.repository.core.security.SpringSecurityProvider"
+            }
+        ]
+    },
+    "storage" : {
+        
+    },
+    "sequencing" : {
+    	"removeDerivedContentWithOriginal" : false,
+        "sequencers" : {
+            "Vorto Sequencer" : {
+                "classname" : "org.eclipse.vorto.repository.core.impl.ModelSequencer",
+                "pathExpressions" : [ "default://(*.type|*.fbmodel|*.infomodel|*.mapping)/jcr:content[@jcr:data]" ]
+            }
+        }
+    }
+}

--- a/repository/repository-server/pom.xml
+++ b/repository/repository-server/pom.xml
@@ -224,8 +224,6 @@
 		    <version>7.7.0</version>
 		</dependency>
 		
-		<!-- Elastic search indexing service (end) -->
-		
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
enhancement/2132 Integration Tests for Elastic Search functionality in Vorto Repository

This change set is mostly about adding integration tests to the Elasticsearch module:

1. Added over 100 integration tests mostly ported from the ones created for the repository-core, with necessary changes
2. Ported SearchTestInfrastructure from repository-core: it spins an Elasticsearch runtime with Allegro on ports differing than defaults to avoid conflicts - see class javadoc
3. Modified POM to accomodate the above and various dependencies (including XTend plugin to validate repository imports)
4. Added model resources for the tests (a subset of resources used in repository-core)
5. Removed some garbage comments in repository-server POM
6. Fixed some typos in repository-core tests where expected result was substituted with test result in assert by mistake

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>