### PR TITLE
bug/2114 Enable Validation for all Attachments

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/ModelRepository.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/core/impl/ModelRepository.java
@@ -719,10 +719,7 @@ public class ModelRepository extends AbstractRepositoryOperation
   public void attachFile(ModelId modelId, FileContent fileContent, IUserContext userContext,
       Tag... tags) throws AttachmentException {
 
-    if (Arrays.asList(tags).stream().filter(tag -> tag.equals(Attachment.TAG_IMPORTED))
-        .collect(Collectors.toList()).isEmpty()) {
-      attachmentValidator.validateAttachment(fileContent, modelId);
-    }
+    attachmentValidator.validateAttachment(fileContent, modelId);
 
     doInSession(session -> {
       try {


### PR DESCRIPTION
Removed conditional check that would only validate attachments if not tagged as "IMPORTED"