### PR TITLE
Remove quotation marks from Content-Disposition header. Fixes #2168

### DIFF
--- a/generators/generator-lambda/generator-lambda-executor/src/main/java/org/eclipse/vorto/plugins/generator/lambda/executor/GeneratorExecutionHandler.java
+++ b/generators/generator-lambda/generator-lambda-executor/src/main/java/org/eclipse/vorto/plugins/generator/lambda/executor/GeneratorExecutionHandler.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.vorto.plugins.generator.lambda.executor;
 
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,9 +38,6 @@ import org.eclipse.vorto.plugin.generator.InvocationContext;
 import org.eclipse.vorto.plugin.generator.adapter.ObjectMapperFactory;
 import org.eclipse.vorto.plugin.utils.ApiGatewayRequest;
 import org.eclipse.vorto.plugin.utils.ApiGatewayResponse;
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class GeneratorExecutionHandler implements RequestStreamHandler {
 
@@ -104,7 +104,7 @@ public class GeneratorExecutionHandler implements RequestStreamHandler {
   private ApiGatewayResponse createResponse(IGenerationResult generatorResult) {
     return ApiGatewayResponse.builder().addHeader("Content-Type", "application/octet-stream")
         .addHeader("Content-Disposition",
-            "attachment; filename=\"" + generatorResult.getFileName() + "\"")
+            "attachment; filename=" + generatorResult.getFileName())
         .setBinaryBody(generatorResult.getContent()).build();
   }
 


### PR DESCRIPTION
@aedelmann I have removed the quotation marks from the header (see explanation in my comment in #2168). Or do you see any reason, why this should not be done?

Signed-off-by: kolotu <kevin.olotu@bosch-si.com>