### PR TITLE
Feature/2208 creating a technical user should require a subject

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -255,7 +255,7 @@
 			<dependency>
 				<groupId>org.webjars</groupId>
 				<artifactId>jquery</artifactId>
-				<version>3.2.1</version>
+				<version>3.4.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/account/IUserAccountService.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/account/IUserAccountService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.vorto.repository.domain.Role;
 import org.eclipse.vorto.repository.domain.Tenant;
 import org.eclipse.vorto.repository.domain.User;
+import org.eclipse.vorto.repository.web.account.dto.TenantTechnicalUserDto;
 import org.springframework.security.core.Authentication;
 
 /**
@@ -59,11 +60,11 @@ public interface IUserAccountService {
    * the given tenant.
    * @param tenantId
    * @param userId
-   * @param authenticationProviderId
+   * @param user
    * @param roles
    * @return always {@literal true} (fails with runtime exception if some operation failed).
    */
-  boolean createTechnicalUserAndAddToTenant(String tenantId, String userId, String authenticationProviderId, Role... roles);
+  boolean createTechnicalUserAndAddToTenant(String tenantId, String userId, TenantTechnicalUserDto user, Role... roles);
 
   /**
    * Returns if the particular user as the role in the Tenant

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/utils/PreConditions.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/utils/PreConditions.java
@@ -12,10 +12,17 @@
  */
 package org.eclipse.vorto.repository.utils;
 
-import java.util.Collection;
 import com.google.common.base.Strings;
+import java.util.Collection;
 
 public class PreConditions {
+
+  public static void withPattern(String pattern, String item, String name) {
+    notNullOrEmpty(item, name);
+    if (!item.matches(pattern)) {
+      throw new IllegalArgumentException(String.format("%s '%s' does not match pattern: '%s'", name, item, pattern));
+    }
+  }
   
   public static void notNullOrEmpty(String item, String name) {
     if (Strings.nullToEmpty(item).trim().isEmpty()) {

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/AccountController.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/AccountController.java
@@ -129,6 +129,10 @@ public class AccountController {
       return new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
     }
 
+    if (Strings.nullToEmpty(user.getSubject()).trim().isEmpty()) {
+      return new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
+    }
+
     if (user.getRoles().stream()
         .anyMatch(role -> role.equals(UserRole.ROLE_SYS_ADMIN))) {
       return new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
@@ -147,7 +151,7 @@ public class AccountController {
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
       }
       return new ResponseEntity<>(
-        accountService.createTechnicalUserAndAddToTenant(tenantId, userId, user.getAuthenticationProviderId(), toRoles(user)),
+        accountService.createTechnicalUserAndAddToTenant(tenantId, userId, user, toRoles(user)),
         HttpStatus.OK
       );
     } catch (IllegalArgumentException e) {

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/dto/TenantTechnicalUserDto.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/account/dto/TenantTechnicalUserDto.java
@@ -26,10 +26,19 @@ package org.eclipse.vorto.repository.web.account.dto;
  */
 public class TenantTechnicalUserDto extends TenantUserDto {
   private String authenticationProviderId;
+  private String subject;
   public String getAuthenticationProviderId() {
     return authenticationProviderId;
   }
-  public void setAuthenticationProviderId(String value) {
+  public TenantTechnicalUserDto setAuthenticationProviderId(String value) {
     this.authenticationProviderId = value;
+    return this;
+  }
+  public String getSubject() {
+    return subject;
+  }
+  public TenantTechnicalUserDto setSubject(String value) {
+    this.subject = value;
+    return this;
   }
 }

--- a/repository/repository-core/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
+++ b/repository/repository-core/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
@@ -85,7 +85,33 @@ public class UserAccountServiceTest extends AbstractIntegrationTest {
   public void testCreateTechnicalUserWithoutAuthenticationProvider() {
     // this implicitly creates the "playground" namespace
     User user = setupUserWithRoles("alex");
-    accountService.createTechnicalUserAndAddToTenant("playground", "pepe", null, Role.USER);
+    accountService.createTechnicalUserAndAddToTenant(
+        "playground", "pepe", new TenantTechnicalUserDto().setSubject("subject").setAuthenticationProviderId(null), Role.USER
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateTechnicalUserWithoutSubject() {
+    User user = setupUserWithRoles("alex");
+    accountService.createTechnicalUserAndAddToTenant(
+        "playground", "pepe", new TenantTechnicalUserDto().setSubject(null).setAuthenticationProviderId("GITHUB"), Role.USER
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateTechnicalUserWithSubjectTooShort() {
+    User user = setupUserWithRoles("alex");
+    accountService.createTechnicalUserAndAddToTenant(
+        "playground", "pepe", new TenantTechnicalUserDto().setSubject("abc").setAuthenticationProviderId("GITHUB"), Role.USER
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateTechnicalUserWithSubjectNotAlphanumeric() {
+    User user = setupUserWithRoles("alex");
+    accountService.createTechnicalUserAndAddToTenant(
+        "playground", "pepe", new TenantTechnicalUserDto().setSubject("!§$%").setAuthenticationProviderId("GITHUB"), Role.USER
+    );
   }
 
   private User setupUserWithRoles(String username) {

--- a/repository/repository-core/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
+++ b/repository/repository-core/src/test/java/org/eclipse/vorto/repository/account/UserAccountServiceTest.java
@@ -20,6 +20,7 @@ import org.eclipse.vorto.repository.core.IUserContext;
 import org.eclipse.vorto.repository.domain.Role;
 import org.eclipse.vorto.repository.domain.Tenant;
 import org.eclipse.vorto.repository.domain.User;
+import org.eclipse.vorto.repository.web.account.dto.TenantTechnicalUserDto;
 import org.eclipse.vorto.repository.workflow.IWorkflowService;
 import org.eclipse.vorto.repository.workflow.impl.DefaultWorkflowService;
 import org.junit.Before;
@@ -70,7 +71,11 @@ public class UserAccountServiceTest extends AbstractIntegrationTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void testCreateTechnicalUserAndAddToNonExistingNamespace() {
-    accountService.createTechnicalUserAndAddToTenant("doesNotExist", "pepe", "GITHUB", Role.USER);
+    accountService.createTechnicalUserAndAddToTenant(
+        "doesNotExist", "pepe",
+        new TenantTechnicalUserDto().setAuthenticationProviderId("GITHUB").setSubject("subject"),
+        Role.USER
+    );
   }
 
   /**

--- a/repository/repository-web/dist/js/controllers/manage/tenantUserManagement.js
+++ b/repository/repository-web/dist/js/controllers/manage/tenantUserManagement.js
@@ -113,6 +113,7 @@ repositoryControllers.controller("createOrUpdateUserController",
         $scope.userPartial = "";
         $scope.selectedUser = null;
         $scope.retrievedUsers = [];
+        $scope.technicalUserSubject = null;
 
         $scope.selectUser = function(user) {
             if (user) {
@@ -123,7 +124,7 @@ repositoryControllers.controller("createOrUpdateUserController",
         }
 
         $scope.highlightUser = function(user) {
-            var element = document.getElementById(user.username);
+            let element = document.getElementById(user.username);
             if (element) {
                 element.style.backgroundColor = '#7fc6e7';
                 element.style.color = '#ffffff'
@@ -131,7 +132,7 @@ repositoryControllers.controller("createOrUpdateUserController",
         }
 
         $scope.unhighlightUser = function(user) {
-            var element = document.getElementById(user.username);
+            let element = document.getElementById(user.username);
             if (element) {
                 element.style.backgroundColor = 'initial';
                 element.style.color = 'initial';
@@ -160,16 +161,15 @@ repositoryControllers.controller("createOrUpdateUserController",
                 $scope.retrievedUsers = [];
                 $scope.selectedUser = null;
             }
+            $scope.toggleSubmitButton();
         };
 
-        //$scope.findUsers();
-        
         $scope.cancel = function() {
             $uibModalInstance.dismiss("Canceled.");  
         };
 
         $scope.promptCreateNewTechnicalUser = function() {
-            var modalInstance = $uibModal.open({
+            let modalInstance = $uibModal.open({
                 animation: true,
                 templateUrl: "webjars/repository-web/dist/partials/admin/createTechnicalUser.html",
                 size: "md",
@@ -194,24 +194,42 @@ repositoryControllers.controller("createOrUpdateUserController",
             $http.post("./rest/tenants/" + $scope.tenant.tenantId + "/users/" + $scope.user.username, {
                 "username": $scope.user.username,
                 "roles" : $scope.getRoles($scope.user),
-                "authenticationProviderId": $scope.selectedAuthenticationProviderId
+                "authenticationProviderId": $scope.selectedAuthenticationProviderId,
+                "subject": $scope.technicalUserSubject
             })
-            .then(function(result) {
-                $uibModalInstance.close($scope.user);
-            }, function(reason) {
-                $scope.errorMessage = "Creation of technical user " +
-                    $scope.user.username + " in namespace " +
-                    $scope.tenant.defaultNamespace + " failed. ";
-            });
+            .then(
+                function(result) {
+                    $uibModalInstance.close($scope.user);
+                },
+                function(reason) {
+                    $scope.errorMessage = "Creation of technical user " +
+                        $scope.user.username + " in namespace " +
+                        $scope.tenant.defaultNamespace + " failed. ";
+                }
+            );
         };
+
+        $scope.toggleSubmitButton = function() {
+            let button = document.getElementById("submitButton");
+            if (button) {
+                button.disabled = !(
+                    ($scope.user && $scope.user.username)
+                    ||
+                    $scope.userPartial
+                    ||
+                    $scope.selectedUser
+                );
+            }
+            return button && !button.disabled;
+        }
 
         $scope.addOrUpdateUser = function() {
             // adds username to scope user by either using selected user from
             // drop-down if any, or using the string in user's input box
             if ($scope.selectedUser) {
-                $scope.user.username = $scope.selectedUser.username;
+                $scope.user = $scope.selectedUser;
             }
-            else {
+            else if ($scope.userPartial) {
                 $scope.user.username = $scope.userPartial;
             }
             $scope.validate($scope.user, function(result) {

--- a/repository/repository-web/dist/partials/admin/createOrUpdateUser.html
+++ b/repository/repository-web/dist/partials/admin/createOrUpdateUser.html
@@ -1,9 +1,5 @@
 <form class="form-horizontal" name="tenantForm">
 	<style>
-		.ng-hide:not(.ng-hide-animate) {
-			display:block;
-			visibility: hidden;
-		}
 		.dropDownUL {
 			list-style-type:none;
 			margin:0;
@@ -35,7 +31,7 @@
 				<div class="col-sm-10">
 					<input autofocus type="search" class="search-box-query-filter form-control search-input"
 					 id="userId" placeholder="userId" ng-model="userPartial" ng-readonly="user.edit"
-					 ng-model-options="{ debounce: 1000 }" ng-change="findUsers()">
+					 ng-model-options="{ debounce: 200 }" ng-change="findUsers()" ng-focus="toggleSubmitButton()">
 				</div>
 			</div>
 			<div class="row">
@@ -116,7 +112,8 @@
 		<div class="form-group">
 			<div class="col-sm-12">
 				<button type="button" class="btn btn-default pull-right" ng-click="cancel()">Cancel</button>
-				<button type="button" class="btn btn-primary pull-right" ng-click="addOrUpdateUser()" ng-disabled="isCurrentlyAddingOrUpdating">
+				<!-- ng-disabled does not seem to work properly or ever refresh -->
+				<button id="submitButton" type="button" class="btn btn-primary pull-right" ng-click="addOrUpdateUser()" ng-disabled="isCurrentlyAddingOrUpdating">
 					<i class="fa fa-refresh fa-spin" ng-show="isCurrentlyAddingOrUpdating"></i>{{ mode }}
 				</button>
 			</div>

--- a/repository/repository-web/dist/partials/admin/createTechnicalUser.html
+++ b/repository/repository-web/dist/partials/admin/createTechnicalUser.html
@@ -6,21 +6,29 @@
        title="Read more about managing Collaborators"><span class="fa fa-question-circle" /></a>
   </h4>
 </div>
-<div class="modal-body">
+<div class="modal-header">
   <div>
-      User <i>{{user.username}}</i> does not exist. <br/><br/>
-      Create a new technical user and add it to the <i>{{tenant.defaultNamespace}}</i> namespace by selecting the
-      desired authentication provider below.
-    <hr/>
+    <h5>User <i>{{user.username}}</i> does not exist. </h5>
+    <br/>
+    Create a new technical user and add it to the <i>{{tenant.defaultNamespace}}</i> namespace by:
+    <br/>
+    <br/>
+    <ul>
+        <li>Choosing a subject</li>
+        <li>Selecting the desired authentication provider</li>
+      </ul>
   </div>
+</div>
 
-
+<div class="modal-body">
   <div class="row" ng-show="errorMessage !== ''">
     <div class="alert alert-danger" role="alert">{{ errorMessage }}</div>
   </div>
 
-  <div class="table">
-    <br/>
+  <div class="form-group">
+    <!-- -->
+    <input ng-pattern="/^[a-zA-Z0-9]{4,}$/" class="form-control" id="subject" type="text" name="subject" ng-model=technicalUserSubject placeholder="Subject" required>
+    <hr/>
     <div ng-repeat="provider in context.providers" class="table-row-cell" >
         <input id={{provider.id}} type="radio" name="authorizationProvider" ng-model=$parent.selectedAuthenticationProviderId class="btn btn-default" value={{provider.id}} />
         <img src="{{provider.logoHref}}" alt="Select {{provider.label}}"/>
@@ -28,10 +36,11 @@
     </div>
   </div>
 </div>
+
 <div class="modal-footer">
   <div class="form-group">
     <button type="button" class="btn btn-default pull-right" ng-click="cancel()">Cancel</button>
-    <button type="button" class="btn btn-primary pull-right" ng-click="createNewTechnicalUser()" ng-disabled="isCurrentlyAddingOrUpdating || !selectedAuthenticationProviderId">
+    <button type="button" class="btn btn-primary pull-right" ng-click="createNewTechnicalUser()" ng-disabled="isCurrentlyAddingOrUpdating || !selectedAuthenticationProviderId || !technicalUserSubject">
       <i class="fa fa-refresh fa-spin" ng-show="isCurrentlyAddingOrUpdating"></i> Create
     </button>
   </div>


### PR DESCRIPTION
* modal for technical user creation now also prompts for subject (required, pattern-validated)
* DTO, controller and back-end now validate, handle and persist the subject
* few changes in adding user to tenant, e.g. button disabled until some username typed (previous implementation was not working and loading animations are still useless pretty much all over the place still now)
* added some failsafes when handling search vs actual usernames in form
* Created a few tests for tech user creation regarding subject