### PR TITLE
security/2210 jQuery 3.2.1 has been found to be vulnerable to prototy…

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -255,7 +255,7 @@
 			<dependency>
 				<groupId>org.webjars</groupId>
 				<artifactId>jquery</artifactId>
-				<version>3.2.1</version>
+				<version>3.4.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>


### PR DESCRIPTION
* changed jquery to 3.4.1

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>