### PR TITLE
#2154

### DIFF
--- a/repository/repository-web/dist/css/style.css
+++ b/repository/repository-web/dist/css/style.css
@@ -1923,3 +1923,14 @@ input[type=file]::-webkit-file-upload-button {
   z-index: 2000;
   text-align: center;
 }
+
+.alert-danger-background {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1999;
+  opacity: 75%;
+  background-color: grey;
+}

--- a/repository/repository-web/dist/partials/templates/session-timeout-warning.html
+++ b/repository/repository-web/dist/partials/templates/session-timeout-warning.html
@@ -1,3 +1,5 @@
+<div ng-show="sessionExpirationWarning" class="alert-danger-background">
+</div>
 <div ng-show="sessionExpirationWarning" class="alert alert-danger alert-danger-stick-top">
   <div ng-if="sessionTimeoutCountdown > 0">
     <p>
@@ -7,7 +9,7 @@
   </div>
   <div ng-if="sessionTimeoutCountdown == 0">
     <p>
-      <i class="fa fa-fw fa-exclamation-triangle"></i>Warning - your session has expired. Please save your work and login again.
+      <i class="fa fa-fw fa-exclamation-triangle"></i>Warning - your session has expired.
     </p>
     <button ng-click="logout()" class="btn btn-primary pull-center">Logout</button>
   </div>


### PR DESCRIPTION
* Grey semi-transparent div covering whole real estate when both warning and session expired banners occur
* The content "behind" it is scrollable but not clickable
* The only way to "un-freeze" the vorto content at this point is to click on the modal's button, whether it's to extend the session or navigate back to the login page depending on the case
* Removed the "save your work" part when session unrecoverable

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>