### PR TITLE
bug/2243 Users without the Publish Permission on a namespace can see …

### DIFF
--- a/repository/repository-web/dist/js/controllers/detailsController.js
+++ b/repository/repository-web/dist/js/controllers/detailsController.js
@@ -30,6 +30,7 @@ repositoryControllers.controller('DetailsController',
 				$scope.encodeURIComponent = encodeURIComponent;
 				$scope.newComment = {value: ""};
 				$scope.canGenerate = true;
+				$scope.canPublishModel = false;
 
 				$scope.editorConfig = {
 					infomodel: {
@@ -291,6 +292,7 @@ repositoryControllers.controller('DetailsController',
 									});
 
 							$scope.getUserPolicy();
+							$scope.getAllUserPolicies();
 						}
 
 						$scope.showReferences = false;
@@ -903,6 +905,17 @@ repositoryControllers.controller('DetailsController',
 							//$scope.modelEditor.setReadOnly(true);
 						}
 					});
+				};
+
+				$scope.getAllUserPolicies = function() {
+					$http.get('./rest/models/' + $scope.modelId + '/policies')
+						.success(function(result) {
+							$scope.canPublishModel = result.some(function(e, i, a) {return e.principalId && e.principalId == "MODEL_PUBLISHER";});
+						})
+						.error(function(data, status, headers, config) {
+							$scope.permission = "READ";
+							$scope.canPublishModel = false;
+						});
 				};
 
 				$scope.diagnoseModel = function () {

--- a/repository/repository-web/dist/partials/details-template.html
+++ b/repository/repository-web/dist/partials/details-template.html
@@ -44,7 +44,7 @@
 				<div class="pull-left">&nbsp;&nbsp;</div>
 			</div>
 			
-			<div ng-show="(hasAuthority('ROLE_SYS_ADMIN') || permission === 'FULL_ACCESS') && model.released && model.visibility === 'private' && hasOfficialPrefix(model)">
+			<div ng-show="(hasAuthority('ROLE_SYS_ADMIN') || canPublishModel) && model.released && model.visibility === 'private' && hasOfficialPrefix(model)">
 				<button class="btn btn-default pull-left"  role="button"
 				    ng-click="makePublic(model)">
 					<span class="fa fa-globe" aria-hidden="true"></span>&nbsp;Publish</button>


### PR DESCRIPTION
…the Publish button

* changed the pre-authorization of ModelRepositoryController#getPolicies to all users
* added call to above endpoint in detailsController to infer whether user can publish
* replaced permission check in template to use flag from controller rather than full access permission

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>