### PR TITLE
bug/2349 Non-Systemadmin users can't save models

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/api/v1/NamespaceController.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/web/api/v1/NamespaceController.java
@@ -558,7 +558,7 @@ public class NamespaceController {
       Predicate<Tenant> filter = hasMemberWithRole(userContext.getUsername(), roleFilter);
       return new ResponseEntity<>(
           tenantService.getTenants().stream().filter(filter)
-              .anyMatch((t) -> t.getDefaultNamespace().equals(namespace)),
+              .anyMatch(t -> namespace.startsWith(t.getDefaultNamespace())),
           HttpStatus.OK
       );
     }


### PR DESCRIPTION
* fixed namespace/tenant equality comparison being too strict wrt to subdomains when checking for user access

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>