### PR TITLE
2380 suite auth access to public models

### DIFF
--- a/repository/repository-oauth-boschid/src/main/java/org/eclipse/vorto/repository/oauth/BoschIoTSuiteOAuthProviderV2.java
+++ b/repository/repository-oauth-boschid/src/main/java/org/eclipse/vorto/repository/oauth/BoschIoTSuiteOAuthProviderV2.java
@@ -110,10 +110,9 @@ public class BoschIoTSuiteOAuthProviderV2 extends AbstractOAuthProvider {
       return false;
     }
 
-    User technicalUser = getTechnicalUser(jwtToken)
+    return getTechnicalUser(jwtToken)
+            .map(user -> true)
             .orElseThrow(() -> new MalformedElement("clientId in jwtToken isn't a registered technical user"));
-
-    return allowAccess(resource(httpRequest), technicalUser);
   }
 
   private Optional<User> getTechnicalUser(JwtToken jwtToken) {
@@ -124,10 +123,6 @@ public class BoschIoTSuiteOAuthProviderV2 extends AbstractOAuthProvider {
 
   private boolean verifyAlgorithm(JwtToken jwtToken) {
     return jwtToken.getHeaderMap().get("alg").equals(RS256_ALG);
-  }
-
-  private boolean allowAccess(Optional<Resource> resource, User user) {
-    return !resource.isPresent() || namespaceApplicableToResource(user, resource.get()).isPresent();
   }
 
   private Optional<Namespace> namespaceApplicableToResource(User user, Resource resource) {

--- a/repository/repository-oauth-boschid/src/test/java/org/eclipse/vorto/repository/oauth/HydraTokenVerifierTest.java
+++ b/repository/repository-oauth-boschid/src/test/java/org/eclipse/vorto/repository/oauth/HydraTokenVerifierTest.java
@@ -66,9 +66,4 @@ public class HydraTokenVerifierTest extends AbstractVerifierTest {
     assertFalse(getVerifier().verify(requestModel("vorto.private.erle:Datatype1:1.0.0"), JwtToken.instance(expiredToken).get()));
   }
   
-  @Test
-  public void verifyInvalidResourceAccess() {
-    assertFalse(getVerifier().verify(requestModel("vorto.private.someoneelse:Datatype1:1.0.0"), JwtToken.instance(jwtToken).get()));
-  }
-  
 }

--- a/repository/repository-oauth-boschid/src/test/java/org/eclipse/vorto/repository/oauth/LegacyTokenVerificationTest.java
+++ b/repository/repository-oauth-boschid/src/test/java/org/eclipse/vorto/repository/oauth/LegacyTokenVerificationTest.java
@@ -54,8 +54,4 @@ public class LegacyTokenVerificationTest extends AbstractVerifierTest {
     assertTrue(getVerifier().verify(requestModel("vorto.private.erle:Datatype1:1.0.0"), JwtToken.instance(jwtToken).get()));
   }
   
-  @Test
-  public void testNoNamespaceAccess() {
-    assertFalse(getVerifier().verify(requestModel("vorto.private.someoneelse:Datatype1:1.0.0"), JwtToken.instance(jwtToken).get()));
-  }
 }

--- a/repository/repository-server/src/main/resources/application.yml
+++ b/repository/repository-server/src/main/resources/application.yml
@@ -75,7 +75,7 @@ oauth2:
       publicKeyUri: https://access.bosch-iot-suite.com/auth/realms/iot-suite/protocol/openid-connect/certs
     hydra:
       issuer: https://access.bosch-iot-suite.com/v2/
-      publicKeyUri: https://identity.bosch.com/.well-known/jwks
+      publicKeyUri: https://access.bosch-iot-suite.com/v2/.well-known/jwks.json
       
 mail:
   smtp:


### PR DESCRIPTION
There was a check in the OAuth handler, that checked whether the OAuth client was a technical user in the namespace of the requested model. IMO this is not necessary as the regular access control applies. 
@mena-bosch maybe have a quick look, to see if you see a reason, why this maybe shouldn't be removed. 