### PR TITLE
2438

### DIFF
--- a/repository/repository-web/dist/partials/admin/namespaceManagement.html
+++ b/repository/repository-web/dist/partials/admin/namespaceManagement.html
@@ -22,7 +22,7 @@
   </div>
   <div class="col-sm-3">
     <button type="button" class="btn btn-primary" ng-click="openRequestAccessToNamespace()">
-      <span class="glyphicon glyphicon glyphicon-user" aria-hidden="true"/>&nbsp;Request access to a
+      <span class="glyphicon glyphicon glyphicon-user" aria-hidden="true"></span>&nbsp;Request access to a
       namespace
     </button>
   </div>


### PR DESCRIPTION
Fixed self-closing span into explicitly closed to not render button caption as part of span with wrongly inherited font-family

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>