### PR TITLE
2524

### DIFF
--- a/repository/repository-web/dist/js/controllers/importController.js
+++ b/repository/repository-web/dist/js/controllers/importController.js
@@ -144,7 +144,7 @@ define(["../init/appController"], function (repositoryControllers) {
                     mappingcount: mappingcount
                   };
                   $scope.beingUploaded = false;
-                  $scope.resultMessage = result.message;
+                  $scope.resultMessage = result.data.message;
                 },
                 function (error) {
                   $scope.isLoading = false;


### PR DESCRIPTION
- Fixes "main" error message div population when uploading a model that cannot be imported (here because the model is released and would be imported in its original namespace)

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>