### PR TITLE
2506/Add a direct link in the e-mail sent to request access to a name…

### DIFF
--- a/repository/repository-web/dist/js/controllers/manage/namespaceUserManagement.js
+++ b/repository/repository-web/dist/js/controllers/manage/namespaceUserManagement.js
@@ -197,6 +197,10 @@ define(["../../init/appController"], function (repositoryControllers) {
           };
 
           $scope.editableUser = function (user) {
+            // default value
+            if (!user.roles) {
+              user.roles = ["model_viewer"];
+            }
             return {
               edit: true,
               // different "username" notations over time caused this

--- a/repository/repository-web/dist/js/controllers/requestAccessToNamespaceController.js
+++ b/repository/repository-web/dist/js/controllers/requestAccessToNamespaceController.js
@@ -14,9 +14,9 @@ define(["../init/appController"], function (repositoryControllers) {
 
   repositoryControllers.controller("requestAccessToNamespaceController",
       ["$rootScope", "$scope", "$http", "$routeParams", "$uibModal",
-        "$location", "modal",
+        "$location", "modal", "$window",
         function ($rootScope, $scope, $http, $routeParams, $uibModal,
-            $location, modal) {
+            $location, modal, $window) {
 
           // infers whether this page is loaded as modal or standalone
           $scope.modal = modal;
@@ -65,6 +65,7 @@ define(["../init/appController"], function (repositoryControllers) {
 
           $scope.reloadPage = function () {
             $location.search({});
+            $window.location.reload();
           }
 
           $scope.loadUserData = function () {
@@ -82,7 +83,7 @@ define(["../init/appController"], function (repositoryControllers) {
                   $scope.paramOauthProvider = $scope.technicalUser.authenticationProvider;
                   $scope.paramSubject = $scope.technicalUser.subject;
                   // disable create user button and change caption
-                  $scope.createUserButtonCaption = "Technical user exists";
+                  $scope.createUserButtonCaption = "User exists";
                   let button = document.getElementById(
                       "createTechnicalUserButton");
                   if (button) {
@@ -543,7 +544,11 @@ define(["../init/appController"], function (repositoryControllers) {
             // AngularJS event handler occurring after DOM ready prevents
             // checking the default radio
             setTimeout(() => {
-              document.getElementById("myself").checked = true;
+              // still possible to have undefined on DOM ready in certain cases
+              let element = document.getElementById("myself");
+              if (element) {
+                element.checked = true;
+              }
             }, 200);
           });
 


### PR DESCRIPTION
…space, pointing to namespace...

# Small fixes for 2506 and related functionalities
- Defaulting model_viewer role if none specified when adding a user to a namespace via parametrized form, and the user is not already a collaborator
- Better caption for "User exists" button on parametrized namespace access request form (it can reference any user, so "technical user exists" is too specific)
- "New request" button fixed when requesting access to a namespace via standalone form (was not reloading the page correctly)
- Another fix in ugly timeout to pre-select "myself" in namespace access request form, as the DOM element may somehow still be undefined even on DOM ready (I don't even want to know why)

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>