### PR TITLE
2491

### DIFF
--- a/core-bundles/language/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/internal/validation/AccordinglyValueValidator.xtend
+++ b/core-bundles/language/org.eclipse.vorto.editor.datatype/src/org/eclipse/vorto/editor/datatype/internal/validation/AccordinglyValueValidator.xtend
@@ -19,6 +19,8 @@ import org.eclipse.vorto.core.api.model.datatype.PrimitiveType
 import org.eclipse.vorto.editor.datatype.validation.DatatypeSystemMessage
 
 class AccordinglyValueValidator extends ConstraintValueValidator {
+
+  val BOOLEAN_VALUES = #["true", "TRUE", "false", "FALSE", "\"true\"", "\"TRUE\"", "\"false\"", "\"FALSE\""]
 	
 	override evaluateValueType(PrimitiveType type, Constraint constraint) {
 		var rawValue = constraint.constraintValues
@@ -41,10 +43,10 @@ class AccordinglyValueValidator extends ConstraintValueValidator {
 						return false
 					}	
 				case 'boolean' :
-					if(rawValue.equalsIgnoreCase("\"true\"") || rawValue.equalsIgnoreCase("\"false\"")) {
+					if(BOOLEAN_VALUES.contains(rawValue)) {
 						return true
 					} else {
-						this.setErrorMessage(DatatypeSystemMessage.ERROR_CONSTRAINT_VALUE_SHORT)
+						this.setErrorMessage(DatatypeSystemMessage.ERROR_CONSTRAINT_VALUE_BOOLEAN)
 						return false
 					}
 				case 'short' :

--- a/repository/repository-server/src/test/java/org/eclipse/vorto/repository/server/it/ModelRepositoryControllerTest.java
+++ b/repository/repository-server/src/test/java/org/eclipse/vorto/repository/server/it/ModelRepositoryControllerTest.java
@@ -304,6 +304,22 @@ public class ModelRepositoryControllerTest extends IntegrationTestBase {
         .andExpect(status().isUnauthorized());
   }
 
+  @Test
+  public void createDatatypeWithBooleanDefaultConstraint() throws Exception {
+    // creates namespace
+    createNamespaceSuccessfully("org.eclipse.vorto.examples.type", userSysadmin);
+    // creates model with constraint
+    createModel(userSysadmin, "HasBooleanDefaultConstraint.type", "org.eclipse.vorto.examples.type.HasBooleanDefaultConstraint:1.0.0" );
+    // cleans up
+    repositoryServer
+        .perform(
+            delete(String.format("/rest/namespaces/%s", "org.eclipse.vorto.examples.type"))
+                .with(userSysadmin)
+        )
+        .andExpect(status().isNoContent());
+
+  }
+
   /**
    * This test performs the following:
    * <ol>

--- a/repository/repository-server/src/test/resources/models/HasBooleanDefaultConstraint.type
+++ b/repository/repository-server/src/test/resources/models/HasBooleanDefaultConstraint.type
@@ -1,0 +1,9 @@
+vortolang 1.0
+
+namespace org.eclipse.vorto.examples.type
+version 1.0.0
+
+entity HasBooleanDefaultConstraint {
+	mandatory boo as boolean <DEFAULT false>
+	blah as boolean <DEFAULT true>
+}


### PR DESCRIPTION
- Fixes boolean value validation contextually to default constraints
- Adds small coverage for simple true vs false default constraints in datatype model

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>