### PR TITLE
2670

### DIFF
--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/importer/StatusMessage.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/importer/StatusMessage.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.vorto.repository.importer;
 
+import com.google.common.base.Strings;
+import java.util.Arrays;
+
 public class StatusMessage {
 
   private String message;
@@ -23,7 +26,43 @@ public class StatusMessage {
     this.severity = severity;
   }
 
-  protected StatusMessage() {}
+  /**
+   * Derives the message from the given {@link Exception} by using its message as main message, but
+   * also aggregating messages from suppressed {@link Exception}s is any.
+   *
+   * @param exception
+   * @param severity
+   */
+  public StatusMessage(Exception exception, MessageSeverity severity) {
+    super();
+    this.severity = severity;
+    if (exception.getSuppressed().length == 0) {
+      this.setMessage(exception.getMessage());
+    } else {
+      String newLine = System.getProperty("line.separator");
+      StringBuilder message = new StringBuilder(exception.getMessage());
+      message.append(newLine).append("[Details:").append(newLine);
+      Arrays.stream(exception.getSuppressed())
+          .forEach(
+              s -> {
+                String suppressedMessage = s.getMessage();
+                if (!Strings.isNullOrEmpty(suppressedMessage)) {
+                  message.append(suppressedMessage).append("; ").append(newLine);
+                }
+              }
+          );
+      // last "; "
+      int lastIndexOfSuppressedSeparator = message.lastIndexOf("; ");
+      if (lastIndexOfSuppressedSeparator > 0) {
+        message.delete(lastIndexOfSuppressedSeparator, message.length());
+      }
+      message.append("]");
+      this.setMessage(message.toString());
+    }
+  }
+
+  protected StatusMessage() {
+  }
 
   public String getMessage() {
     return message;
@@ -57,23 +96,28 @@ public class StatusMessage {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj)
+    if (this == obj) {
       return true;
-    if (obj == null)
+    }
+    if (obj == null) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+    if (getClass() != obj.getClass()) {
       return false;
+    }
     StatusMessage other = (StatusMessage) obj;
     if (message == null) {
-      if (other.message != null)
+      if (other.message != null) {
         return false;
-    } else if (!message.equals(other.message))
+      }
+    } else if (!message.equals(other.message)) {
       return false;
-    if (severity != other.severity)
+    }
+    if (severity != other.severity) {
       return false;
+    }
     return true;
   }
-
 
 
 }

--- a/repository/repository-core/src/main/java/org/eclipse/vorto/repository/importer/ValidationReport.java
+++ b/repository/repository-core/src/main/java/org/eclipse/vorto/repository/importer/ValidationReport.java
@@ -77,11 +77,11 @@ public class ValidationReport {
     if (exception instanceof CouldNotResolveReferenceException) {
       CouldNotResolveReferenceException ex = (CouldNotResolveReferenceException) exception;
       return new ValidationReport(model, false,
-          new StatusMessage(exception.getMessage(), MessageSeverity.ERROR),
+          new StatusMessage(exception, MessageSeverity.ERROR),
           ex.getMissingReferences(), ex.getValidationIssues());
     } else {
       return new ValidationReport(model, false,
-          new StatusMessage(exception.getMessage(), MessageSeverity.ERROR), Collections.emptyList(),
+          new StatusMessage(exception, MessageSeverity.ERROR), Collections.emptyList(),
           exception.getValidationIssues());
 
     }

--- a/repository/repository-server/src/test/java/org/eclipse/vorto/repository/server/it/ModelRepositoryControllerTest.java
+++ b/repository/repository-server/src/test/java/org/eclipse/vorto/repository/server/it/ModelRepositoryControllerTest.java
@@ -789,4 +789,87 @@ public class ModelRepositoryControllerTest extends IntegrationTestBase {
         .andExpect(status().isNoContent());
   }
 
+  /**
+   * Minimal coverage for model with malformed vortolang (missing a value for namespace). <br/>
+   * The parsing behavior is slightly different between models created for integration tests and
+   * models created in real life through REST/UI insofar as the parsing here fails early and no
+   * list of {@link org.eclipse.emf.ecore.EObject} can be retrieved from the resource's contents
+   * in the {@link org.eclipse.vorto.repository.core.impl.parser.AbstractModelParser} at test time,
+   * meaning the failure to parse occurs earlier and displays a generic "Xtext cannot parse..."
+   * message.<br/>
+   * Conversely when saving a similar model in the UI, the parser will create the
+   * {@link org.eclipse.emf.ecore.EObject}, but then populate the
+   * {@link org.eclipse.vorto.core.api.model.model.Model} with {@code null} values when parsing
+   * failed, which will require an additional validation and return more elaborate error messages.
+   * <br/>
+   * Bottomline, only checking for bad response status here.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void createModelMissingNamespace() throws Exception {
+    // creates namespace
+    createNamespaceSuccessfully("org.eclipse.vorto.examples.type", userSysadmin);
+    // creates model with constraint
+
+    repositoryServer
+        .perform(post(
+            "/rest/models/org.eclipse.vorto.examples.type.MissingNamespace:1.0.0/"
+                + ModelType.fromFileName("MissingNamespace.type"))
+            .with(userSysadmin).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    repositoryServer
+        .perform(
+            put("/rest/models/org.eclipse.vorto.examples.type.MissingNamespace:1.0.0")
+                .with(userSysadmin)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createContent("MissingNamespace.type")))
+        .andExpect(status().isBadRequest());
+
+    // cleans up
+    repositoryServer
+        .perform(
+            delete(String.format("/rest/namespaces/%s", "org.eclipse.vorto.examples.type"))
+                .with(userSysadmin)
+        )
+        .andExpect(status().isNoContent());
+  }
+
+  /**
+   * See {@link ModelRepositoryControllerTest#createModelMissingNamespace()} for rationale on
+   * testing strategy.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void createModelMissingVersion() throws Exception {
+    // creates namespace
+    createNamespaceSuccessfully("org.eclipse.vorto.examples.type", userSysadmin);
+    // creates model with constraint
+
+    repositoryServer
+        .perform(post(
+            "/rest/models/org.eclipse.vorto.examples.type.MissingVersion:1.0.0/"
+                + ModelType.fromFileName("MissingVersion.type"))
+            .with(userSysadmin).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    repositoryServer
+        .perform(
+            put("/rest/models/org.eclipse.vorto.examples.type.MissingVersion:1.0.0")
+                .with(userSysadmin)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createContent("MissingVersion.type")))
+        .andExpect(status().isBadRequest());
+
+    // cleans up
+    repositoryServer
+        .perform(
+            delete(String.format("/rest/namespaces/%s", "org.eclipse.vorto.examples.type"))
+                .with(userSysadmin)
+        )
+        .andExpect(status().isNoContent());
+  }
+
 }

--- a/repository/repository-server/src/test/resources/models/MissingNamespace.type
+++ b/repository/repository-server/src/test/resources/models/MissingNamespace.type
@@ -1,0 +1,8 @@
+vortolang 1.0
+
+namespace
+version 1.0.0
+
+entity MissingNamespace {
+
+}

--- a/repository/repository-server/src/test/resources/models/MissingVersion.type
+++ b/repository/repository-server/src/test/resources/models/MissingVersion.type
@@ -1,0 +1,8 @@
+vortolang 1.0
+
+namespace org.eclipse.vorto.examples.type
+version
+
+entity MissingVersion {
+
+}


### PR DESCRIPTION
- Reinforced model parsing by preventing unrecoverable NPE when model fields parsed as null (only seems to occur with UI / REST operations - integration tests work slightly differently)

- Added broad coverage for completely broken syntax, but no check on new error messages since integration test models are parsed differently - this will get better coverage at UI level

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>