### PR TITLE
2624

### DIFF
--- a/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/SearchTestInfrastructure.java
+++ b/repository/repository-elasticsearch/src/test/java/org/eclipse/vorto/repository/search/SearchTestInfrastructure.java
@@ -403,7 +403,7 @@ public final class SearchTestInfrastructure {
         new HttpHost(this.elasticSearch.getContainerIpAddress(), this.elasticSearch.getMappedPort(9200), "http")
     );
     searchService = new ElasticSearchService(new RestHighLevelClient(clientBuilder),
-        repositoryFactory, userNamespaceRoleService, namespaceRepository);
+        repositoryFactory, userNamespaceRoleService);
 
     indexingService = (IIndexingService) searchService;
     IndexingEventListener indexingSupervisor = new IndexingEventListener(indexingService);


### PR DESCRIPTION
- ES service uses namespace cache
- Lowered logging levels to debug

This does not resolve the deprecation of ES API calls still in use after the 7.9.3 upgrade. 

Signed-off-by: Menahem Julien Raccah Lisei <menahemjulien.raccahlisei@bosch-si.com>