### PR TITLE
Migrated all com.bosch.iot.suite.edge.containers Vorto models.

### DIFF
--- a/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/model.datatype
@@ -1,0 +1,32 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "Configuration"
+description "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent"
+using com.bosch.iot.suite.edge.containers.MountPoint ; 1.0.0
+using com.bosch.iot.suite.edge.containers.Device ; 1.0.0
+using com.bosch.iot.suite.edge.containers.RestartPolicy ; 1.0.0
+using com.bosch.iot.suite.edge.containers.PortMapping ; 1.0.0
+using com.bosch.iot.suite.edge.containers.LogConfiguration ; 1.0.0
+
+entity Configuration {
+	optional domainName as string "The container domain"
+
+	optional multiple mountPoints as MountPoint "The container's mount points"
+
+	optional multiple devices as Device "Host devices accessible by the container"
+
+	optional privileged as boolean "Indicates if the container must be run in privileged mode"
+
+	optional restartPolicy as RestartPolicy "Restart policy for the container instance"
+
+	optional multiple extraHosts as string "Host aliases to be added to the container's networking configuration"
+
+	optional multiple portMappings as PortMapping "Ports exposed from the container to the host"
+
+	optional openStdin as boolean "Open stdin for interactive mode"
+
+	optional tty as boolean "Attach standard streams to a TTY, including stdin if it is not closed"
+
+	optional log as LogConfiguration "Represents the logging configuration for the container"
+}

--- a/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-Configuration-1.0.0.type/model.json
@@ -1,0 +1,801 @@
+{
+  "root" : {
+    "name" : "Configuration",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/model.functionblock
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/model.functionblock
@@ -1,0 +1,31 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "Container"
+description "Provides lifecycle management functionalities per container and enhances container state changes traceability"
+using com.bosch.iot.suite.edge.containers.Configuration ; 1.0.0
+using com.bosch.iot.suite.edge.containers.State ; 1.0.0
+using com.bosch.iot.suite.edge.containers.StopOptions ; 1.0.0
+
+functionblock Container {
+	status {
+		optional name as string "The container's user-friendly name"
+        mandatory imageRef as
+		string "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>"
+
+		optional config as
+		Configuration "Provides the read-only container's configuration provided when the container was created"
+        mandatory createdAt as string "A container's creation timestamp"
+        mandatory state as State "The current container's state"     
+  }
+
+	operations {
+	   start() "Starts the container instance"
+       pause() "Pauses the container instance"
+       resume() "Resumes the container instance"
+       stop() "Stops the container instance"
+       stopWithOptions(options as StopOptions) "Stops the container instance applying the provided options"
+       remove(force as boolean) "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing"
+  }
+
+}

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.0.0.fbmodel/model.json
@@ -1,0 +1,1245 @@
+{
+  "root" : {
+    "name" : "Container",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Container:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "Container",
+      "description" : "Provides lifecycle management functionalities per container and enhances container state changes traceability",
+      "category" : null,
+      "fileName" : "Container.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      }, {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+      }, {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "name",
+        "description" : "The container's user-friendly name",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "imageRef",
+        "description" : "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "config",
+        "description" : "Provides the read-only container's configuration provided when the container was created",
+        "type" : {
+          "name" : "Configuration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "createdAt",
+        "description" : "A container's creation timestamp",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "state",
+        "description" : "The current container's state",
+        "type" : {
+          "name" : "State",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "start",
+        "description" : "Starts the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "pause",
+        "description" : "Pauses the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "resume",
+        "description" : "Resumes the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stop",
+        "description" : "Stops the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stopWithOptions",
+        "description" : "Stops the container instance applying the provided options",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "options",
+          "description" : null,
+          "type" : {
+            "name" : "StopOptions",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.0.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "force",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:State:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "State",
+      "description" : "Represents the current container's full state given the container's lifecycle",
+      "category" : null,
+      "fileName" : "State.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "pid",
+        "description" : "Represents the container's process's PID",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "error",
+        "description" : "Indicates whether there was a problem that has occurred while changing the state of a container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "exitCode",
+        "description" : "Represents the last exit code of the container's internal root process",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "startedAt",
+        "description" : "A timestamp of the last successfull container's start operation",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "finishedAt",
+        "description" : "A timestamp of the last container's exit",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2021 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/model.functionblock
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/model.functionblock
@@ -1,0 +1,31 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.1.0
+displayname "Container"
+description "Provides lifecycle management functionalities per container and enhances container state changes traceability"
+using com.bosch.iot.suite.edge.containers.Configuration ; 1.0.0
+using com.bosch.iot.suite.edge.containers.State ; 1.0.0
+using com.bosch.iot.suite.edge.containers.StopOptions ; 1.1.0
+
+functionblock Container {
+	status {
+		optional name as string "The container's user-friendly name"
+        mandatory imageRef as
+		string "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>"
+
+		optional config as
+		Configuration "Provides the read-only container's configuration provided when the container was created"
+        mandatory createdAt as string "A container's creation timestamp"
+        mandatory state as State "The current container's state"     
+  }
+
+	operations {
+	   start() "Starts the container instance"
+       pause() "Pauses the container instance"
+       resume() "Resumes the container instance"
+       stop() "Stops the container instance"
+       stopWithOptions(options as StopOptions) "Stops the container instance applying the provided options"
+       remove(force as boolean) "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing"
+  }
+
+}

--- a/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-Container-1.1.0.fbmodel/model.json
@@ -1,0 +1,1263 @@
+{
+  "root" : {
+    "name" : "Container",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.1.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.1.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Container:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.1.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "Container",
+      "description" : "Provides lifecycle management functionalities per container and enhances container state changes traceability",
+      "category" : null,
+      "fileName" : "Container.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      }, {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+      }, {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "name",
+        "description" : "The container's user-friendly name",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "imageRef",
+        "description" : "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "config",
+        "description" : "Provides the read-only container's configuration provided when the container was created",
+        "type" : {
+          "name" : "Configuration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "createdAt",
+        "description" : "A container's creation timestamp",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "state",
+        "description" : "The current container's state",
+        "type" : {
+          "name" : "State",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "start",
+        "description" : "Starts the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "pause",
+        "description" : "Pauses the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "resume",
+        "description" : "Resumes the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stop",
+        "description" : "Stops the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stopWithOptions",
+        "description" : "Stops the container instance applying the provided options",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "options",
+          "description" : null,
+          "type" : {
+            "name" : "StopOptions",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.1.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "force",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "false"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "signal",
+        "description" : "A specific signal to send to the container in order to stop it. Signals could be specified by using their names or numbers, e.g. SIGINT or 2. The default is SIGTERM",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"SIGTERM\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:State:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "State",
+      "description" : "Represents the current container's full state given the container's lifecycle",
+      "category" : null,
+      "fileName" : "State.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "pid",
+        "description" : "Represents the container's process's PID",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "error",
+        "description" : "Indicates whether there was a problem that has occurred while changing the state of a container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "exitCode",
+        "description" : "Represents the last exit code of the container's internal root process",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "startedAt",
+        "description" : "A timestamp of the last successfull container's start operation",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "finishedAt",
+        "description" : "A timestamp of the last container's exit",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/model.functionblock
+++ b/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/model.functionblock
@@ -1,0 +1,18 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "ContainerFactory"
+description "Provides the containers creation functionality"
+using com.bosch.iot.suite.edge.containers.Configuration ; 1.0.0
+
+functionblock ContainerFactory {
+	operations {
+		create(imageRef as string,
+			start as boolean) returns string "Creates a new container instance using the provided image ref applying the default config for a container"
+    createWithConfig(imageRef as string,
+			name as string,
+			config as Configuration,
+			start as boolean) returns string "Creates a new container instance and a feature must be registered based on the provided config"
+  }
+
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-ContainerFactory-1.0.0.fbmodel/model.json
@@ -1,0 +1,928 @@
+{
+  "root" : {
+    "name" : "ContainerFactory",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ContainerFactory",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "ContainerFactory",
+      "description" : "Provides the containers creation functionality",
+      "category" : null,
+      "fileName" : "ContainerFactory.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "create",
+        "description" : "Creates a new container instance using the provided image ref applying the default config for a container",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "createWithConfig",
+        "description" : "Creates a new container instance and a feature must be registered based on the provided config",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "name",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "config",
+          "description" : null,
+          "type" : {
+            "name" : "Configuration",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.0.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/model.informationmodel
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/model.informationmodel
@@ -1,0 +1,18 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "ContainersDevice"
+description "A device that supports containers management via SOTA and locally"
+
+using org.eclipse.hawkbit.swupdatable.SoftwareUpdatable;2.0.0
+using com.bosch.iot.suite.edge.containers.ContainerFactory;1.0.0
+using com.bosch.iot.suite.edge.containers.Container;1.0.0
+
+
+infomodel ContainersDevice {
+  functionblocks {
+    mandatory ContainerFactory as ContainerFactory "Containers creation entry point"
+    multiple Container as Container "Represents a single container instance and its management"
+    mandatory SoftwareUpdatable as SoftwareUpdatable "Supports containers SOTA"
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.0.0.infomodel/model.json
@@ -1,0 +1,3672 @@
+{
+  "root" : {
+    "name" : "ContainersDevice",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainersDevice:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareUpdatable",
+        "namespace" : "org.eclipse.hawkbit.swupdatable",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "SoftwareUpdatable",
+      "description" : "Represents the ability of a device to install and manage a certain type of software.",
+      "category" : null,
+      "fileName" : "SoftwareUpdatable.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "SoftwareUpdateAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+      }, {
+        "name" : "SoftwareRemoveAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      }, {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "softwareModuleType",
+        "description" : "The type of the software managed by this feature.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "installedDependencies",
+        "description" : "List of all installed software managed by this feature. The key should be the concatenated group.name:version.",
+        "type" : {
+          "key" : "STRING",
+          "value" : {
+            "name" : "DependencyDescription",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "1.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "contextDependencies",
+        "description" : "Information additional dependencies relevant for software installation, e.g. hardware parts or runtimes like OSGi container or JREs.",
+        "type" : {
+          "key" : "STRING",
+          "value" : {
+            "name" : "DependencyDescription",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "1.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "lastOperation",
+        "description" : "The last operation's status response.",
+        "type" : {
+          "name" : "OperationStatus",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "lastFailedOperation",
+        "description" : "The last operation status indicating a finished with error.",
+        "type" : {
+          "name" : "OperationStatus",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "install",
+        "description" : "Instruction to download and install.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "download",
+        "description" : "Instruction to download (without installing).",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "cancel",
+        "description" : "Try to cancel a running installation.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Remove an installed software.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "software",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareRemoveAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "cancelRemove",
+        "description" : "Try to cancel a remove operation.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "software",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareRemoveAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:OperationStatus:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "OperationStatus",
+      "description" : "Entity representing the status of an operation (install/remove) called on a device.",
+      "category" : null,
+      "fileName" : "OperationStatus.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+      }, {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      }, {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      }, {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "Id used for correlating the status-update with the operation called before.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "One of the predefined status, representing the failure, progress or sucess of the operation.",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "softwareModule",
+        "description" : "Required in the case of an install/download/cancel operation, absent in case of remove or cancelRemove.",
+        "type" : {
+          "name" : "SoftwareModuleId",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "software",
+        "description" : "Required for a remove or cancelRemove operation, absent in case of install/download/cancel.",
+        "type" : {
+          "name" : "DependencyDescription",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "1.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "progress",
+        "description" : "A progress indicator in percentage.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "100"
+        } ],
+        "attributes" : [ {
+          "type" : "MEASUREMENT_UNIT",
+          "value" : {
+            "name" : "percent",
+            "description" : null,
+            "parent" : {
+              "name" : "Unit",
+              "namespace" : "org.eclipse.vorto",
+              "version" : "1.0.1",
+              "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+            }
+          }
+        } ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "message",
+        "description" : "Message from the device to give more context to the transmitted status.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "statusCode",
+        "description" : "Custom status code transmitted by the device.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareDescription",
+      "description" : "Describes a software installed on the device.",
+      "category" : null,
+      "fileName" : "DependencyDescription.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "group",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name of the software.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version of the software.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Status:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Datatype for Status",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "STARTED",
+        "description" : "Confirmation that the request is received.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADING",
+        "description" : "Required dependencies are being downloaded.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADING_WAITING",
+        "description" : "In the state of downloading, but waiting for another operation to complete. Ex: user confirmation.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADED",
+        "description" : "Software has been downloaded.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLING",
+        "description" : "Software is being installed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLING_WAITING",
+        "description" : "In the state of installing, but waiting for another operation to complete. Ex: user confirmation, completion of another software etc.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLED",
+        "description" : "Software has been installed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVING",
+        "description" : "Software is in the progress of beeing removed",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVING_WAITING",
+        "description" : "Software remove is waiting for some conditions, e.g. user-confirmation",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVED",
+        "description" : "Software part has been removed - final sucess of all removals should report FINISHED_SUCCESS",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCELING",
+        "description" : "Operation is being cancelled.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCELING_WAITING",
+        "description" : "Cancel is waiting. Ex: user confirmation.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCEL_REJECTED",
+        "description" : "Cancel could not be performed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_CANCELED",
+        "description" : "Operation is successfully cancelled.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_ERROR",
+        "description" : "Operation is completed with errors.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_SUCCESS",
+        "description" : "Operation is completed successfully.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_WARNING",
+        "description" : "Operation is completed with warnings.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_REJECTED",
+        "description" : "Operation is rejected.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Container:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "Container",
+      "description" : "Provides lifecycle management functionalities per container and enhances container state changes traceability",
+      "category" : null,
+      "fileName" : "Container.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      }, {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+      }, {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "name",
+        "description" : "The container's user-friendly name",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "imageRef",
+        "description" : "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "config",
+        "description" : "Provides the read-only container's configuration provided when the container was created",
+        "type" : {
+          "name" : "Configuration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "createdAt",
+        "description" : "A container's creation timestamp",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "state",
+        "description" : "The current container's state",
+        "type" : {
+          "name" : "State",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "start",
+        "description" : "Starts the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "pause",
+        "description" : "Pauses the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "resume",
+        "description" : "Resumes the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stop",
+        "description" : "Stops the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stopWithOptions",
+        "description" : "Stops the container instance applying the provided options",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "options",
+          "description" : null,
+          "type" : {
+            "name" : "StopOptions",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.0.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "force",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:State:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "State",
+      "description" : "Represents the current container's full state given the container's lifecycle",
+      "category" : null,
+      "fileName" : "State.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "pid",
+        "description" : "Represents the container's process's PID",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "error",
+        "description" : "Indicates whether there was a problem that has occurred while changing the state of a container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "exitCode",
+        "description" : "Represents the last exit code of the container's internal root process",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "startedAt",
+        "description" : "A timestamp of the last successfull container's start operation",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "finishedAt",
+        "description" : "A timestamp of the last container's exit",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:ContainersDevice:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ContainersDevice",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainersDevice:1.0.0"
+      },
+      "type" : "InformationModel",
+      "displayName" : "ContainersDevice",
+      "description" : "A device that supports containers management via SOTA and locally",
+      "category" : null,
+      "fileName" : "ContainersDevice.infomodel",
+      "modelType" : "Infomodel",
+      "references" : [ {
+        "name" : "SoftwareUpdatable",
+        "namespace" : "org.eclipse.hawkbit.swupdatable",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+      }, {
+        "name" : "ContainerFactory",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+      }, {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.0.0"
+      } ],
+      "functionblocks" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "ContainerFactory",
+        "description" : "Containers creation entry point",
+        "type" : {
+          "name" : "ContainerFactory",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "Container",
+        "description" : "Represents a single container instance and its management",
+        "type" : {
+          "name" : "Container",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "SoftwareUpdatable",
+        "description" : "Supports containers SOTA",
+        "type" : {
+          "name" : "SoftwareUpdatable",
+          "namespace" : "org.eclipse.hawkbit.swupdatable",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Protocol:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Protocol",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Protocol",
+      "description" : "Protocol provided for downloading an artificat",
+      "category" : null,
+      "fileName" : "Protocol.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "HTTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "HTTPS",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "FTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "SFTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:Url:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Url",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Url:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Url",
+      "description" : "Datatype for Url",
+      "category" : null,
+      "fileName" : "Url.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "http",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "https",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareArtifactAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareArtifactAction",
+      "description" : "Datatype for SoftwareArtifactAction",
+      "category" : null,
+      "fileName" : "SoftwareArtifactAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      }, {
+        "name" : "Protocol",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+      }, {
+        "name" : "Hash",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+      }, {
+        "name" : "Links",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "filename",
+        "description" : "Filename of the software module artifact.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "download",
+        "description" : "Urls to download the artifact.",
+        "type" : {
+          "key" : {
+            "name" : "Protocol",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+          },
+          "value" : {
+            "name" : "Links",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "checksums",
+        "description" : "Checkum values for checksum urls.",
+        "type" : {
+          "key" : {
+            "name" : "Hash",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+          },
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "size",
+        "description" : "Artifact size.",
+        "type" : "LONG",
+        "constraints" : [ ],
+        "attributes" : [ {
+          "type" : "MEASUREMENT_UNIT",
+          "value" : {
+            "name" : "Byte",
+            "description" : null,
+            "parent" : {
+              "name" : "Unit",
+              "namespace" : "org.eclipse.vorto",
+              "version" : "1.0.1",
+              "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+            }
+          }
+        } ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareUpdateAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareUpdateAction",
+      "description" : "Parameter used for instructing the device to install or download one or more software.",
+      "category" : null,
+      "fileName" : "SoftwareUpdateAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "SoftwareModuleAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "An identifier used to correlate the status updates sent from the device for this action.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "softwareModules",
+        "description" : "Software modules that needs to be processed.",
+        "type" : {
+          "name" : "SoftwareModuleAction",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "weight",
+        "description" : "Priority in case of multiple, parallel installation instructions.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "1000"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "Any other information which should be passed to the device.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Indicates the urgency of the update. when true, the device should install as soon as possible.",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareModuleAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareModuleAction",
+      "description" : "Parameter representing a software module - a collection of artifacts to be downloaded and installed",
+      "category" : null,
+      "fileName" : "SoftwareModuleAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "SoftwareArtifactAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+      }, {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "softwareModule",
+        "description" : "A unique indentifier for the software module.",
+        "type" : {
+          "name" : "SoftwareModuleId",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "artifacts",
+        "description" : "List of software artifacts contained in the module.",
+        "type" : {
+          "name" : "SoftwareArtifactAction",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "Any other information which should be passed to the device.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareModuleId:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareModuleId",
+      "description" : "Unique identifier for software-modules",
+      "category" : null,
+      "fileName" : "SoftwareModuleId.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name for the software module.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version of the software module.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.vorto:Unit:1.0.1" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      },
+      "type" : "Datatype",
+      "displayName" : "Unit",
+      "description" : "SI units plus some common imperial units",
+      "category" : null,
+      "fileName" : "Unit.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "second",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "metre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "ampere",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "mole",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "candela",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "squareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "cubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "metrePerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "reciprocalMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogramPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogramPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "cubicMetrePerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "amperePerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "amperePerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "molePerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "candelaPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "steriadian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "hertz",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newton",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pascal",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joule",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "watt",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulomb",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "volt",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "farad",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "ohm",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "siemens",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "weber",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "tesla",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "henry",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "degreeCelsius",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "lumen",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "lux",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "becquerel",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "gray",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "sievert",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "katal",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pascalSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newtonMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newtonPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radianPerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radianPerSecondSquared",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKilogramKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerMetreKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "voltPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "faradPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "henryPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerMole",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerMoleKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "grayPerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSteradian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSquareMetreSteradia",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "katalPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "calorie",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kiloCalorie",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "inch",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "feet",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "yard",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "mile",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "nauticalMile",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pound",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "stone",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "poundPerSquareInch",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "milePerHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "fahrenheit",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "percent",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "beatsPerMinute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "rotationsPerMinute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilometre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilometrePerHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "degreeAngle",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "secondsSinceBegin1970",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "minute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "bar",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "millibar",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kiloWattHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "Byte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilobyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "megabyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "gigabyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Links:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Links",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Links",
+      "description" : "Datatype for Links",
+      "category" : null,
+      "fileName" : "Links.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Url",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Url:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "url",
+        "description" : "Url to download the artifact.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "md5url",
+        "description" : "Url to download the MD5SUM file.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:Hash:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Hash",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Hash",
+      "description" : "Datatype for Hash",
+      "category" : null,
+      "fileName" : "Hash.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "SHA1",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      }, {
+        "name" : "MD5",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      }, {
+        "name" : "SHA256",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:DependencyDescription:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "DependencyDescription",
+      "description" : "Describes an installed software or other dependencies for a device.",
+      "category" : null,
+      "fileName" : "DependencyDescription.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "group",
+        "description" : "Group name (e.g. vendor). This should be unique together with name.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name of the software or hardware part.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version or value uniquely identifying the software or hardware.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "An additional classification type, e.g. hw-part, docker, etc.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ContainerFactory",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "ContainerFactory",
+      "description" : "Provides the containers creation functionality",
+      "category" : null,
+      "fileName" : "ContainerFactory.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "create",
+        "description" : "Creates a new container instance using the provided image ref applying the default config for a container",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "createWithConfig",
+        "description" : "Creates a new container instance and a feature must be registered based on the provided config",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "name",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "config",
+          "description" : null,
+          "type" : {
+            "name" : "Configuration",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.0.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareRemoveAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareRemoveAction",
+      "description" : "Action instructing the device to remove a defined set of software.",
+      "category" : null,
+      "fileName" : "SoftwareRemoveAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "An identifier used to correlate the status updates sent from the device for this action.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "software",
+        "description" : "Software to be removed.",
+        "type" : {
+          "name" : "DependencyDescription",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "1.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "weight",
+        "description" : "Priority in case of multiple, parallel instructions.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "1000"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "MetaData associated with Eclipse hawkBit's Distribution Set.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Indicates the urgency of the update, when true the device should install as soon as possible.",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2021 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/model.informationmodel
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/model.informationmodel
@@ -1,0 +1,20 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.1.0
+displayname "ContainersDevice"
+description "A device that supports containers management via SOTA and locally"
+
+using org.eclipse.ditto.ConnectionStatus;1.0.0
+using org.eclipse.hawkbit.swupdatable.SoftwareUpdatable;2.0.0
+using com.bosch.iot.suite.edge.containers.ContainerFactory;1.0.0
+using com.bosch.iot.suite.edge.containers.Container;1.1.0
+
+
+infomodel ContainersDevice {
+  functionblocks {
+    mandatory ContainerFactory as ContainerFactory "Containers creation entry point"
+    multiple Container as Container "Represents a single container instance and its management"
+    mandatory SoftwareUpdatable as SoftwareUpdatable "Supports containers SOTA"
+    mandatory ConnectionStatus as ConnectionStatus "Information about the connectivity status of the device"
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-ContainersDevice-1.1.0.infomodel/model.json
@@ -1,0 +1,3761 @@
+{
+  "root" : {
+    "name" : "ContainersDevice",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.1.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainersDevice:1.1.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareUpdatable",
+        "namespace" : "org.eclipse.hawkbit.swupdatable",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "SoftwareUpdatable",
+      "description" : "Represents the ability of a device to install and manage a certain type of software.",
+      "category" : null,
+      "fileName" : "SoftwareUpdatable.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "SoftwareUpdateAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+      }, {
+        "name" : "SoftwareRemoveAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      }, {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      }, {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "softwareModuleType",
+        "description" : "The type of the software managed by this feature.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "installedDependencies",
+        "description" : "List of all installed software managed by this feature. The key should be the concatenated group.name:version.",
+        "type" : {
+          "key" : "STRING",
+          "value" : {
+            "name" : "DependencyDescription",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "1.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "contextDependencies",
+        "description" : "Information additional dependencies relevant for software installation, e.g. hardware parts or runtimes like OSGi container or JREs.",
+        "type" : {
+          "key" : "STRING",
+          "value" : {
+            "name" : "DependencyDescription",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "1.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "lastOperation",
+        "description" : "The last operation's status response.",
+        "type" : {
+          "name" : "OperationStatus",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "lastFailedOperation",
+        "description" : "The last operation status indicating a finished with error.",
+        "type" : {
+          "name" : "OperationStatus",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "install",
+        "description" : "Instruction to download and install.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "download",
+        "description" : "Instruction to download (without installing).",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "cancel",
+        "description" : "Try to cancel a running installation.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "update",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareUpdateAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Remove an installed software.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "software",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareRemoveAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "cancelRemove",
+        "description" : "Try to cancel a remove operation.",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "software",
+          "description" : null,
+          "type" : {
+            "name" : "SoftwareRemoveAction",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:OperationStatus:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "OperationStatus",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:OperationStatus:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "OperationStatus",
+      "description" : "Entity representing the status of an operation (install/remove) called on a device.",
+      "category" : null,
+      "fileName" : "OperationStatus.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+      }, {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      }, {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      }, {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "Id used for correlating the status-update with the operation called before.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "One of the predefined status, representing the failure, progress or sucess of the operation.",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "softwareModule",
+        "description" : "Required in the case of an install/download/cancel operation, absent in case of remove or cancelRemove.",
+        "type" : {
+          "name" : "SoftwareModuleId",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "software",
+        "description" : "Required for a remove or cancelRemove operation, absent in case of install/download/cancel.",
+        "type" : {
+          "name" : "DependencyDescription",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "1.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "progress",
+        "description" : "A progress indicator in percentage.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "100"
+        } ],
+        "attributes" : [ {
+          "type" : "MEASUREMENT_UNIT",
+          "value" : {
+            "name" : "percent",
+            "description" : null,
+            "parent" : {
+              "name" : "Unit",
+              "namespace" : "org.eclipse.vorto",
+              "version" : "1.0.1",
+              "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+            }
+          }
+        } ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "message",
+        "description" : "Message from the device to give more context to the transmitted status.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "statusCode",
+        "description" : "Custom status code transmitted by the device.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Configuration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Configuration",
+      "description" : "Represents a fully featured container configuration supported by the Bosch IoT Edge Agent",
+      "category" : null,
+      "fileName" : "Configuration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      }, {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      }, {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      }, {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      }, {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "domainName",
+        "description" : "The container domain",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mountPoints",
+        "description" : "The container's mount points",
+        "type" : {
+          "name" : "MountPoint",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "devices",
+        "description" : "Host devices accessible by the container",
+        "type" : {
+          "name" : "Device",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "privileged",
+        "description" : "Indicates if the container must be run in privileged mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "restartPolicy",
+        "description" : "Restart policy for the container instance",
+        "type" : {
+          "name" : "RestartPolicy",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "extraHosts",
+        "description" : "Host aliases to be added to the container's networking configuration",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "portMappings",
+        "description" : "Ports exposed from the container to the host",
+        "type" : {
+          "name" : "PortMapping",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "openStdin",
+        "description" : "Open stdin for interactive mode",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "tty",
+        "description" : "Attach standard streams to a TTY, including stdin if it is not closed",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "log",
+        "description" : "Represents the logging configuration for the container",
+        "type" : {
+          "name" : "LogConfiguration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareDescription",
+      "description" : "Describes a software installed on the device.",
+      "category" : null,
+      "fileName" : "DependencyDescription.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "group",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name of the software.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version of the software.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Status:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Datatype for Status",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "STARTED",
+        "description" : "Confirmation that the request is received.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADING",
+        "description" : "Required dependencies are being downloaded.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADING_WAITING",
+        "description" : "In the state of downloading, but waiting for another operation to complete. Ex: user confirmation.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "DOWNLOADED",
+        "description" : "Software has been downloaded.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLING",
+        "description" : "Software is being installed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLING_WAITING",
+        "description" : "In the state of installing, but waiting for another operation to complete. Ex: user confirmation, completion of another software etc.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "INSTALLED",
+        "description" : "Software has been installed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVING",
+        "description" : "Software is in the progress of beeing removed",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVING_WAITING",
+        "description" : "Software remove is waiting for some conditions, e.g. user-confirmation",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "REMOVED",
+        "description" : "Software part has been removed - final sucess of all removals should report FINISHED_SUCCESS",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCELING",
+        "description" : "Operation is being cancelled.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCELING_WAITING",
+        "description" : "Cancel is waiting. Ex: user confirmation.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "CANCEL_REJECTED",
+        "description" : "Cancel could not be performed.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_CANCELED",
+        "description" : "Operation is successfully cancelled.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_ERROR",
+        "description" : "Operation is completed with errors.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_SUCCESS",
+        "description" : "Operation is completed successfully.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_WARNING",
+        "description" : "Operation is completed with warnings.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      }, {
+        "name" : "FINISHED_REJECTED",
+        "description" : "Operation is rejected.",
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Status:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Container:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.1.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "Container",
+      "description" : "Provides lifecycle management functionalities per container and enhances container state changes traceability",
+      "category" : null,
+      "fileName" : "Container.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      }, {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+      }, {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      }, {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "name",
+        "description" : "The container's user-friendly name",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "imageRef",
+        "description" : "The container's image full reference in the format <host/ip[:port]>/<image-name>:<tag>",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "config",
+        "description" : "Provides the read-only container's configuration provided when the container was created",
+        "type" : {
+          "name" : "Configuration",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "createdAt",
+        "description" : "A container's creation timestamp",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "state",
+        "description" : "The current container's state",
+        "type" : {
+          "name" : "State",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "start",
+        "description" : "Starts the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "pause",
+        "description" : "Pauses the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "resume",
+        "description" : "Resumes the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stop",
+        "description" : "Stops the container instance",
+        "result" : null,
+        "params" : [ ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "stopWithOptions",
+        "description" : "Stops the container instance applying the provided options",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "options",
+          "description" : null,
+          "type" : {
+            "name" : "StopOptions",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.1.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "remove",
+        "description" : "Removes the container instance and feature (if the removal is successful) and forces the removal if the container is runing",
+        "result" : null,
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "force",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.ditto:ConnectionStatus:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ConnectionStatus",
+        "namespace" : "org.eclipse.ditto",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.ditto:ConnectionStatus:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "ConnectionStatus",
+      "description" : "Information about the status of the connectivity to a device",
+      "category" : null,
+      "fileName" : "ConnectionStatus.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "readySince",
+        "description" : "Timestamp when the device or the connectivity endpoint signals that the device is connected and stays connected at least for some time and is ready for receiving information",
+        "type" : "DATETIME",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "readyUntil",
+        "description" : "Timestamp until when device or the connectivity endpoint signals that it stays ready for receiving information; if it signals that it stays connected and is ready until further notice then this timestamp is symbolically set to a timestamp that is at least 1 year ahead of now",
+        "type" : "DATETIME",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "false"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "signal",
+        "description" : "A specific signal to send to the container in order to stop it. Signals could be specified by using their names or numbers, e.g. SIGINT or 2. The default is SIGTERM",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"SIGTERM\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:State:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "State",
+      "description" : "Represents the current container's full state given the container's lifecycle",
+      "category" : null,
+      "fileName" : "State.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "pid",
+        "description" : "Represents the container's process's PID",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "error",
+        "description" : "Indicates whether there was a problem that has occurred while changing the state of a container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "exitCode",
+        "description" : "Represents the last exit code of the container's internal root process",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "startedAt",
+        "description" : "A timestamp of the last successfull container's start operation",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "finishedAt",
+        "description" : "A timestamp of the last container's exit",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:ContainersDevice:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ContainersDevice",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainersDevice:1.1.0"
+      },
+      "type" : "InformationModel",
+      "displayName" : "ContainersDevice",
+      "description" : "A device that supports containers management via SOTA and locally",
+      "category" : null,
+      "fileName" : "ContainersDevice.infomodel",
+      "modelType" : "Infomodel",
+      "references" : [ {
+        "name" : "ConnectionStatus",
+        "namespace" : "org.eclipse.ditto",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.ditto:ConnectionStatus:1.0.0"
+      }, {
+        "name" : "SoftwareUpdatable",
+        "namespace" : "org.eclipse.hawkbit.swupdatable",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+      }, {
+        "name" : "ContainerFactory",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+      }, {
+        "name" : "Container",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.1.0"
+      } ],
+      "functionblocks" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "ContainerFactory",
+        "description" : "Containers creation entry point",
+        "type" : {
+          "name" : "ContainerFactory",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "Container",
+        "description" : "Represents a single container instance and its management",
+        "type" : {
+          "name" : "Container",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.1.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Container:1.1.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "SoftwareUpdatable",
+        "description" : "Supports containers SOTA",
+        "type" : {
+          "name" : "SoftwareUpdatable",
+          "namespace" : "org.eclipse.hawkbit.swupdatable",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit.swupdatable:SoftwareUpdatable:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "ConnectionStatus",
+        "description" : "Information about the connectivity status of the device",
+        "type" : {
+          "name" : "ConnectionStatus",
+          "namespace" : "org.eclipse.ditto",
+          "version" : "1.0.0",
+          "prettyFormat" : "org.eclipse.ditto:ConnectionStatus:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Protocol:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Protocol",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Protocol",
+      "description" : "Protocol provided for downloading an artificat",
+      "category" : null,
+      "fileName" : "Protocol.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "HTTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "HTTPS",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "FTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      }, {
+        "name" : "SFTP",
+        "description" : null,
+        "parent" : {
+          "name" : "Protocol",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:Url:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Url",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Url:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Url",
+      "description" : "Datatype for Url",
+      "category" : null,
+      "fileName" : "Url.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "http",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "https",
+        "description" : null,
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareArtifactAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareArtifactAction",
+      "description" : "Datatype for SoftwareArtifactAction",
+      "category" : null,
+      "fileName" : "SoftwareArtifactAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      }, {
+        "name" : "Protocol",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+      }, {
+        "name" : "Hash",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+      }, {
+        "name" : "Links",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "filename",
+        "description" : "Filename of the software module artifact.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "download",
+        "description" : "Urls to download the artifact.",
+        "type" : {
+          "key" : {
+            "name" : "Protocol",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
+          },
+          "value" : {
+            "name" : "Links",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+          },
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "checksums",
+        "description" : "Checkum values for checksum urls.",
+        "type" : {
+          "key" : {
+            "name" : "Hash",
+            "namespace" : "org.eclipse.hawkbit",
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+          },
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "size",
+        "description" : "Artifact size.",
+        "type" : "LONG",
+        "constraints" : [ ],
+        "attributes" : [ {
+          "type" : "MEASUREMENT_UNIT",
+          "value" : {
+            "name" : "Byte",
+            "description" : null,
+            "parent" : {
+              "name" : "Unit",
+              "namespace" : "org.eclipse.vorto",
+              "version" : "1.0.1",
+              "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+            }
+          }
+        } ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareUpdateAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareUpdateAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareUpdateAction",
+      "description" : "Parameter used for instructing the device to install or download one or more software.",
+      "category" : null,
+      "fileName" : "SoftwareUpdateAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "SoftwareModuleAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "An identifier used to correlate the status updates sent from the device for this action.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "softwareModules",
+        "description" : "Software modules that needs to be processed.",
+        "type" : {
+          "name" : "SoftwareModuleAction",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "weight",
+        "description" : "Priority in case of multiple, parallel installation instructions.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "1000"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "Any other information which should be passed to the device.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Indicates the urgency of the update. when true, the device should install as soon as possible.",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareModuleAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareModuleAction",
+      "description" : "Parameter representing a software module - a collection of artifacts to be downloaded and installed",
+      "category" : null,
+      "fileName" : "SoftwareModuleAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "SoftwareArtifactAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+      }, {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "softwareModule",
+        "description" : "A unique indentifier for the software module.",
+        "type" : {
+          "name" : "SoftwareModuleId",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "artifacts",
+        "description" : "List of software artifacts contained in the module.",
+        "type" : {
+          "name" : "SoftwareArtifactAction",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:SoftwareArtifactAction:2.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "Any other information which should be passed to the device.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareModuleId:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareModuleId",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareModuleId:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareModuleId",
+      "description" : "Unique identifier for software-modules",
+      "category" : null,
+      "fileName" : "SoftwareModuleId.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name for the software module.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version of the software module.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.vorto:Unit:1.0.1" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Unit",
+        "namespace" : "org.eclipse.vorto",
+        "version" : "1.0.1",
+        "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+      },
+      "type" : "Datatype",
+      "displayName" : "Unit",
+      "description" : "SI units plus some common imperial units",
+      "category" : null,
+      "fileName" : "Unit.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "second",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "metre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "ampere",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "mole",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "candela",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "squareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "cubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "metrePerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "reciprocalMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogramPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilogramPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "cubicMetrePerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "amperePerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "amperePerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "molePerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "candelaPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "steriadian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "hertz",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newton",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pascal",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joule",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "watt",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulomb",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "volt",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "farad",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "ohm",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "siemens",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "weber",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "tesla",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "henry",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "degreeCelsius",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "lumen",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "lux",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "becquerel",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "gray",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "sievert",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "katal",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pascalSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newtonMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "newtonPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radianPerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "radianPerSecondSquared",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKilogramKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerMetreKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "voltPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerSquareMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "faradPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "henryPerMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerMole",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "joulePerMoleKelvin",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "coulombPerKilogram",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "grayPerSecond",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSteradian",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "wattPerSquareMetreSteradia",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "katalPerCubicMetre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "calorie",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kiloCalorie",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "inch",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "feet",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "yard",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "mile",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "nauticalMile",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "pound",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "stone",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "poundPerSquareInch",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "milePerHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "fahrenheit",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "percent",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "beatsPerMinute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "rotationsPerMinute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilometre",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilometrePerHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "degreeAngle",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "secondsSinceBegin1970",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "minute",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "bar",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "millibar",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kiloWattHour",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "Byte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "kilobyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "megabyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      }, {
+        "name" : "gigabyte",
+        "description" : null,
+        "parent" : {
+          "name" : "Unit",
+          "namespace" : "org.eclipse.vorto",
+          "version" : "1.0.1",
+          "prettyFormat" : "org.eclipse.vorto:Unit:1.0.1"
+        }
+      } ]
+    },
+    "org.eclipse.hawkbit:Links:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Links",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Links:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Links",
+      "description" : "Datatype for Links",
+      "category" : null,
+      "fileName" : "Links.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Url",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Url:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "url",
+        "description" : "Url to download the artifact.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "md5url",
+        "description" : "Url to download the MD5SUM file.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:Hash:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Hash",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Hash",
+      "description" : "Datatype for Hash",
+      "category" : null,
+      "fileName" : "Hash.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "SHA1",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      }, {
+        "name" : "MD5",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      }, {
+        "name" : "SHA256",
+        "description" : null,
+        "parent" : {
+          "name" : "Hash",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:Hash:2.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:DependencyDescription:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "DependencyDescription",
+      "description" : "Describes an installed software or other dependencies for a device.",
+      "category" : null,
+      "fileName" : "DependencyDescription.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "group",
+        "description" : "Group name (e.g. vendor). This should be unique together with name.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "name",
+        "description" : "Name of the software or hardware part.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "version",
+        "description" : "Version or value uniquely identifying the software or hardware.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "An additional classification type, e.g. hw-part, docker, etc.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "ContainerFactory",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:ContainerFactory:1.0.0"
+      },
+      "type" : "Functionblock",
+      "displayName" : "ContainerFactory",
+      "description" : "Provides the containers creation functionality",
+      "category" : null,
+      "fileName" : "ContainerFactory.fbmodel",
+      "modelType" : "FunctionblockModel",
+      "references" : [ {
+        "name" : "Configuration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+      } ],
+      "configurationProperties" : [ ],
+      "statusProperties" : [ ],
+      "faultProperties" : [ ],
+      "events" : [ ],
+      "operations" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "create",
+        "description" : "Creates a new container instance using the provided image ref applying the default config for a container",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "name" : "createWithConfig",
+        "description" : "Creates a new container instance and a feature must be registered based on the provided config",
+        "result" : {
+          "type" : "STRING",
+          "primitive" : true,
+          "multiple" : false
+        },
+        "params" : [ {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "imageRef",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "name",
+          "description" : null,
+          "type" : "STRING",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "config",
+          "description" : null,
+          "type" : {
+            "name" : "Configuration",
+            "namespace" : "com.bosch.iot.suite.edge.containers",
+            "version" : "1.0.0",
+            "prettyFormat" : "com.bosch.iot.suite.edge.containers:Configuration:1.0.0"
+          },
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : false
+        }, {
+          "targetPlatformKey" : null,
+          "stereotypes" : [ ],
+          "mappingReference" : null,
+          "mandatory" : false,
+          "name" : "start",
+          "description" : null,
+          "type" : "BOOLEAN",
+          "constraints" : [ ],
+          "multiple" : false,
+          "primitive" : true
+        } ],
+        "breakable" : false
+      } ],
+      "superType" : null
+    },
+    "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "SoftwareRemoveAction",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "SoftwareRemoveAction",
+      "description" : "Action instructing the device to remove a defined set of software.",
+      "category" : null,
+      "fileName" : "SoftwareRemoveAction.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "DependencyDescription",
+        "namespace" : "org.eclipse.hawkbit",
+        "version" : "1.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "correlationId",
+        "description" : "An identifier used to correlate the status updates sent from the device for this action.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "software",
+        "description" : "Software to be removed.",
+        "type" : {
+          "name" : "DependencyDescription",
+          "namespace" : "org.eclipse.hawkbit",
+          "version" : "1.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : true,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "weight",
+        "description" : "Priority in case of multiple, parallel instructions.",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "0"
+        }, {
+          "type" : "MAX",
+          "value" : "1000"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "metadata",
+        "description" : "MetaData associated with Eclipse hawkBit's Distribution Set.",
+        "type" : {
+          "key" : "STRING",
+          "value" : "STRING",
+          "type" : "dictionary"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Indicates the urgency of the update, when true the device should install as soon as possible.",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/model.datatype
@@ -1,0 +1,12 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "Device"
+description "Represents a serial device exposed from the host to the container mapped to a certain internal container's path"
+
+entity Device {
+  mandatory pathOnHost as string "Device path on the host machine"
+  mandatory pathInContainer as string "Device path inside the container"
+
+	optional cgroupPermissions as string "cgroup permissions"
+}

--- a/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-Device-1.0.0.type/model.json
@@ -1,0 +1,67 @@
+{
+  "root" : {
+    "name" : "Device",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:Device:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Device",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Device:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Device",
+      "description" : "Represents a serial device exposed from the host to the container mapped to a certain internal container's path",
+      "category" : null,
+      "fileName" : "Device.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathOnHost",
+        "description" : "Device path on the host machine",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "pathInContainer",
+        "description" : "Device path inside the container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "cgroupPermissions",
+        "description" : "cgroup permissions",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/model.datatype
@@ -1,0 +1,22 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "LogConfiguration"
+description "Represents the full logging configuration for a container instance"
+using com.bosch.iot.suite.edge.containers.LogMode ; 1.0.0
+using com.bosch.iot.suite.edge.containers.LogDriver ; 1.0.0
+
+entity LogConfiguration {
+	optional type as
+	LogDriver "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE"
+
+	optional maxFiles as int <DEFAULT 2> "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed"
+
+	optional maxSize as string <DEFAULT "100M"> "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)"
+
+	optional rootDir as
+	string "The root directory where to store the logs for the container under a subdirectory named by its ID"
+
+	optional mode as LogMode "Log messages handling mode (buffered or direct) from the container to the log driver"
+
+	optional maxBufferSize as string <DEFAULT "1M"> "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)" }

--- a/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-LogConfiguration-1.0.0.type/model.json
@@ -1,0 +1,208 @@
+{
+  "root" : {
+    "name" : "LogConfiguration",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogConfiguration",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogConfiguration:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogConfiguration",
+      "description" : "Represents the full logging configuration for a container instance",
+      "category" : null,
+      "fileName" : "LogConfiguration.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      }, {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "Indicates what kind of logging will be made for this container instance. The default is JSON_FILE",
+        "type" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxFiles",
+        "description" : "The maximum number of log files permitted. If the rolled logs output creates excess files, the oldest one is removed",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "2"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxSize",
+        "description" : "The maximum size of the log before it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"100M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "rootDir",
+        "description" : "The root directory where to store the logs for the container under a subdirectory named by its ID",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "mode",
+        "description" : "Log messages handling mode (buffered or direct) from the container to the log driver",
+        "type" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxBufferSize",
+        "description" : "The maximum size of the log buffer it is rolled. Must be in the form of an integer followed by a modifier representing the unit of measure (k, M, G or T)",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"1M\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/model.datatype
@@ -1,0 +1,10 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "LogDriver"
+description "Represents the different supported types of logging that can be made for a container instance"
+
+enum LogDriver {
+    JSON_FILE,
+    NONE
+}

--- a/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-LogDriver-1.0.0.type/model.json
@@ -1,0 +1,48 @@
+{
+  "root" : {
+    "name" : "LogDriver",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogDriver",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogDriver",
+      "description" : "Represents the different supported types of logging that can be made for a container instance",
+      "category" : null,
+      "fileName" : "LogDriver.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "JSON_FILE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      }, {
+        "name" : "NONE",
+        "description" : null,
+        "parent" : {
+          "name" : "LogDriver",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogDriver:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/model.datatype
@@ -1,0 +1,10 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "LogMode"
+description "Represents the log messages handling mode (buffered or direct) from the container to the log driver"
+
+enum LogMode {
+    BLOCKING,
+    NON_BLOCKING
+}

--- a/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-LogMode-1.0.0.type/model.json
@@ -1,0 +1,48 @@
+{
+  "root" : {
+    "name" : "LogMode",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:LogMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "LogMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "LogMode",
+      "description" : "Represents the log messages handling mode (buffered or direct) from the container to the log driver",
+      "category" : null,
+      "fileName" : "LogMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      }, {
+        "name" : "NON_BLOCKING",
+        "description" : null,
+        "parent" : {
+          "name" : "LogMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:LogMode:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/model.datatype
@@ -1,0 +1,13 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "MountPoint"
+description "Represents filesystem artifacts mounted from the host to the container"
+using com.bosch.iot.suite.edge.containers.PropagationMode ; 1.0.0
+
+entity MountPoint {
+ mandatory source as string "Path to the source mount point"
+ mandatory destination as string "Path to the container mount point"
+
+	optional propagationMode as PropagationMode "Propagation mode of the mount point"
+}

--- a/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-MountPoint-1.0.0.type/model.json
@@ -1,0 +1,151 @@
+{
+  "root" : {
+    "name" : "MountPoint",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "MountPoint",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:MountPoint:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "MountPoint",
+      "description" : "Represents filesystem artifacts mounted from the host to the container",
+      "category" : null,
+      "fileName" : "MountPoint.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "source",
+        "description" : "Path to the source mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "destination",
+        "description" : "Path to the container mount point",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "propagationMode",
+        "description" : "Propagation mode of the mount point",
+        "type" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    },
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/model.datatype
@@ -1,0 +1,15 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "PortMapping"
+description "Represents a network port mappings for ports from the container exposed on the host's network interface"
+
+entity PortMapping {
+	optional proto as string "Port protocol"
+ mandatory hostPort as int "Port of the host machine"
+
+	optional hostPortEnd as int "Host port allocation range"
+ mandatory containerPort as int "Port inside the container"
+
+	optional hostIP as string "IP Address of the port to be mapped"
+}

--- a/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-PortMapping-1.0.0.type/model.json
@@ -1,0 +1,91 @@
+{
+  "root" : {
+    "name" : "PortMapping",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PortMapping",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PortMapping:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PortMapping",
+      "description" : "Represents a network port mappings for ports from the container exposed on the host's network interface",
+      "category" : null,
+      "fileName" : "PortMapping.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "proto",
+        "description" : "Port protocol",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "hostPort",
+        "description" : "Port of the host machine",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostPortEnd",
+        "description" : "Host port allocation range",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "containerPort",
+        "description" : "Port inside the container",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "hostIP",
+        "description" : "IP Address of the port to be mapped",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/model.datatype
@@ -1,0 +1,14 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "PropagationMode"
+description "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container"
+
+enum PropagationMode {
+    RPRIVATE,
+    PRIVATE,
+    RSHARED,
+    SHARED,
+    RSLAVE,
+    SLAVE
+}

--- a/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-PropagationMode-1.0.0.type/model.json
@@ -1,0 +1,84 @@
+{
+  "root" : {
+    "name" : "PropagationMode",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "PropagationMode",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "PropagationMode",
+      "description" : "Represents the propagation mode for populating the mounted filesystem artifacts from the host to the container",
+      "category" : null,
+      "fileName" : "PropagationMode.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "RPRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "PRIVATE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SHARED",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "RSLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      }, {
+        "name" : "SLAVE",
+        "description" : null,
+        "parent" : {
+          "name" : "PropagationMode",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:PropagationMode:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/model.datatype
@@ -1,0 +1,13 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "RestartPolicy"
+description "Represents the container's restart policy configuratoin"
+using com.bosch.iot.suite.edge.containers.RestartPolicyType ; 1.0.0
+
+entity RestartPolicy {
+	optional maxRetryCount as int "Max number of restart attempts"
+
+	optional retryTimeout as int "Retry timeout in seconds"
+  mandatory type as RestartPolicyType "The type of the container's restart policy"
+}

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicy-1.0.0.type/model.json
@@ -1,0 +1,133 @@
+{
+  "root" : {
+    "name" : "RestartPolicy",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicy",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicy:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicy",
+      "description" : "Represents the container's restart policy configuratoin",
+      "category" : null,
+      "fileName" : "RestartPolicy.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "maxRetryCount",
+        "description" : "Max number of restart attempts",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "retryTimeout",
+        "description" : "Retry timeout in seconds",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "type",
+        "description" : "The type of the container's restart policy",
+        "type" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/model.datatype
@@ -1,0 +1,12 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "RestartPolicyType"
+description "Represents the container's restart policy type - always means that each time te container exists, it will be restarted."
+
+enum RestartPolicyType {
+  ALWAYS,
+  UNLESS_STOPPED,
+  ON_FAILURE,
+  NO
+ }

--- a/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-RestartPolicyType-1.0.0.type/model.json
@@ -1,0 +1,66 @@
+{
+  "root" : {
+    "name" : "RestartPolicyType",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "RestartPolicyType",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "RestartPolicyType",
+      "description" : "Represents the container's restart policy type - always means that each time te container exists, it will be restarted.",
+      "category" : null,
+      "fileName" : "RestartPolicyType.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "ALWAYS",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "UNLESS_STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "ON_FAILURE",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      }, {
+        "name" : "NO",
+        "description" : null,
+        "parent" : {
+          "name" : "RestartPolicyType",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:RestartPolicyType:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/model.datatype
@@ -1,0 +1,22 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "State"
+description "Represents the current container's full state given the container's lifecycle"
+using com.bosch.iot.suite.edge.containers.Status ; 1.0.0
+
+entity State {
+  mandatory status as
+	Status "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown"
+
+	optional pid as int "Represents the container's process's PID"
+
+	optional error as
+	string "Indicates whether there was a problem that has occurred while changing the state of a container"
+
+	optional exitCode as int "Represents the last exit code of the container's internal root process"
+
+	optional startedAt as string "A timestamp of the last successfull container's start operation"
+
+	optional finishedAt as string "A timestamp of the last container's exit"
+ }

--- a/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-State-1.0.0.type/model.json
@@ -1,0 +1,205 @@
+{
+  "root" : {
+    "name" : "State",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    },
+    "com.bosch.iot.suite.edge.containers:State:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "State",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:State:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "State",
+      "description" : "Represents the current container's full state given the container's lifecycle",
+      "category" : null,
+      "fileName" : "State.type",
+      "modelType" : "EntityModel",
+      "references" : [ {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      } ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : true,
+        "name" : "status",
+        "description" : "Represents the status of this container - Creating, Created, Running, Stopped, Paused, Exited, Dead, Unknown",
+        "type" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        },
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : false
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "pid",
+        "description" : "Represents the container's process's PID",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "error",
+        "description" : "Indicates whether there was a problem that has occurred while changing the state of a container",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "exitCode",
+        "description" : "Represents the last exit code of the container's internal root process",
+        "type" : "INT",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "startedAt",
+        "description" : "A timestamp of the last successfull container's start operation",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "finishedAt",
+        "description" : "A timestamp of the last container's exit",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/model.datatype
@@ -1,0 +1,16 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "Status"
+description "Represents the current container's status given the container's lifecycle"
+
+enum Status {
+    CREATING,
+    CREATED,
+    RUNNING,
+    STOPPED,
+    PAUSED,
+    EXITED,
+    DEAD,
+    UNKNOWN
+}

--- a/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-Status-1.0.0.type/model.json
@@ -1,0 +1,102 @@
+{
+  "root" : {
+    "name" : "Status",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:Status:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "Status",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "Status",
+      "description" : "Represents the current container's status given the container's lifecycle",
+      "category" : null,
+      "fileName" : "Status.type",
+      "modelType" : "EnumModel",
+      "references" : [ ],
+      "literals" : [ {
+        "name" : "CREATING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "CREATED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "RUNNING",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "STOPPED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "PAUSED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "EXITED",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "DEAD",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      }, {
+        "name" : "UNKNOWN",
+        "description" : null,
+        "parent" : {
+          "name" : "Status",
+          "namespace" : "com.bosch.iot.suite.edge.containers",
+          "version" : "1.0.0",
+          "prettyFormat" : "com.bosch.iot.suite.edge.containers:Status:1.0.0"
+        }
+      } ]
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2020 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/model.datatype
@@ -1,0 +1,12 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.0.0
+displayname "StopOptions"
+description "Represents the container stop options"
+
+entity StopOptions {
+	optional forced as
+	boolean "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true"
+
+	optional timeout as int <DEFAULT 30> "A timeout period in seconds in which the container must stop"
+}

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.0.0.type/model.json
@@ -1,0 +1,58 @@
+{
+  "root" : {
+    "name" : "StopOptions",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.0.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.0.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.0.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/COPYRIGHT.txt
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+Copyright (C) 2021 Bosch.IO GmbH

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/model.datatype
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/model.datatype
@@ -1,0 +1,13 @@
+vortolang 1.0
+namespace com.bosch.iot.suite.edge.containers
+version 1.1.0
+displayname "StopOptions"
+description "Represents the container stop options"
+
+entity StopOptions {
+	optional forced as boolean <DEFAULT false> "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true"
+
+	optional timeout as int <DEFAULT 30> "A timeout period in seconds in which the container must stop"
+	
+	optional signal as string <DEFAULT "SIGTERM"> "A specific signal to send to the container in order to stop it. Signals could be specified by using their names or numbers, e.g. SIGINT or 2. The default is SIGTERM"
+}

--- a/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/model.json
+++ b/models/com.bosch.iot.suite.edge.containers-StopOptions-1.1.0.type/model.json
@@ -1,0 +1,76 @@
+{
+  "root" : {
+    "name" : "StopOptions",
+    "namespace" : "com.bosch.iot.suite.edge.containers",
+    "version" : "1.1.0",
+    "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+  },
+  "models" : {
+    "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0" : {
+      "targetPlatformKey" : null,
+      "stereotypes" : [ ],
+      "mappingReference" : null,
+      "vortolang" : "1.0",
+      "id" : {
+        "name" : "StopOptions",
+        "namespace" : "com.bosch.iot.suite.edge.containers",
+        "version" : "1.1.0",
+        "prettyFormat" : "com.bosch.iot.suite.edge.containers:StopOptions:1.1.0"
+      },
+      "type" : "Datatype",
+      "displayName" : "StopOptions",
+      "description" : "Represents the container stop options",
+      "category" : null,
+      "fileName" : "StopOptions.type",
+      "modelType" : "EntityModel",
+      "references" : [ ],
+      "properties" : [ {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "forced",
+        "description" : "Whether to send a SIG_KILL signal to the container's process if it does not finish within the timeout specified. The default is true",
+        "type" : "BOOLEAN",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "false"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "timeout",
+        "description" : "A timeout period in seconds in which the container must stop",
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "30"
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "signal",
+        "description" : "A specific signal to send to the container in order to stop it. Signals could be specified by using their names or numbers, e.g. SIGINT or 2. The default is SIGTERM",
+        "type" : "STRING",
+        "constraints" : [ {
+          "type" : "DEFAULT",
+          "value" : "\"SIGTERM\""
+        } ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      } ],
+      "superType" : null
+    }
+  }
+}


### PR DESCRIPTION
Moved all com.bosch.iot.suite.edge.containers namespaced Vorto models that refer to and are used by the Bosch IoT Edge Agent edge containers management.

Signed-off-by: Konstantina Gramatova konstantina.gramatova@bosch.io