### PR TITLE
Removed wrong transitive dependency for DependencyDescription:1.0.0

### DIFF
--- a/models/com.bosch.iot.suite.edge.services-BundleSoftwareUpdatable-1.0.0.fbmodel/model.json
+++ b/models/com.bosch.iot.suite.edge.services-BundleSoftwareUpdatable-1.0.0.fbmodel/model.json
@@ -79,8 +79,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -100,8 +100,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -368,8 +368,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],
@@ -487,63 +487,6 @@
           "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
         }
       } ]
-    },
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
-      "targetPlatformKey" : null,
-      "stereotypes" : [ ],
-      "mappingReference" : null,
-      "vortolang" : "1.0",
-      "id" : {
-        "name" : "DependencyDescription",
-        "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
-      },
-      "type" : "Datatype",
-      "displayName" : "SoftwareDescription",
-      "description" : "Describes a software installed on the device.",
-      "category" : null,
-      "fileName" : "DependencyDescription.type",
-      "modelType" : "EntityModel",
-      "references" : [ ],
-      "properties" : [ {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : false,
-        "name" : "group",
-        "description" : null,
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "name",
-        "description" : "Name of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "version",
-        "description" : "Version of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      } ],
-      "superType" : null
     },
     "org.eclipse.hawkbit:Url:1.0.0" : {
       "targetPlatformKey" : null,
@@ -1197,8 +1140,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -1218,8 +1161,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -2413,8 +2356,8 @@
       "references" : [ {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       } ],
       "properties" : [ {
         "targetPlatformKey" : null,
@@ -2438,8 +2381,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],

--- a/models/com.bosch.iot.suite.edge.vendor.nxp.frdm_k64f-FreedomK64F-1.0.0.infomodel/model.json
+++ b/models/com.bosch.iot.suite.edge.vendor.nxp.frdm_k64f-FreedomK64F-1.0.0.infomodel/model.json
@@ -136,8 +136,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -157,8 +157,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -425,8 +425,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],
@@ -612,63 +612,6 @@
       "faultProperties" : [ ],
       "events" : [ ],
       "operations" : [ ],
-      "superType" : null
-    },
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
-      "targetPlatformKey" : null,
-      "stereotypes" : [ ],
-      "mappingReference" : null,
-      "vortolang" : "1.0",
-      "id" : {
-        "name" : "DependencyDescription",
-        "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
-      },
-      "type" : "Datatype",
-      "displayName" : "SoftwareDescription",
-      "description" : "Describes a software installed on the device.",
-      "category" : null,
-      "fileName" : "DependencyDescription.type",
-      "modelType" : "EntityModel",
-      "references" : [ ],
-      "properties" : [ {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : false,
-        "name" : "group",
-        "description" : null,
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "name",
-        "description" : "Name of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "version",
-        "description" : "Version of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      } ],
       "superType" : null
     },
     "org.eclipse.vorto.std.unit:AccelerationUnit:1.0.0" : {
@@ -2643,8 +2586,8 @@
       "references" : [ {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       } ],
       "properties" : [ {
         "targetPlatformKey" : null,
@@ -2668,8 +2611,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],

--- a/models/com.bosch.iot.suite.example-VirtualDemoDevice-2.0.0.infomodel/model.json
+++ b/models/com.bosch.iot.suite.example-VirtualDemoDevice-2.0.0.infomodel/model.json
@@ -143,8 +143,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -164,8 +164,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -553,8 +553,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],
@@ -672,63 +672,6 @@
           "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
         }
       } ]
-    },
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
-      "targetPlatformKey" : null,
-      "stereotypes" : [ ],
-      "mappingReference" : null,
-      "vortolang" : "1.0",
-      "id" : {
-        "name" : "DependencyDescription",
-        "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
-      },
-      "type" : "Datatype",
-      "displayName" : "SoftwareDescription",
-      "description" : "Describes a software installed on the device.",
-      "category" : null,
-      "fileName" : "DependencyDescription.type",
-      "modelType" : "EntityModel",
-      "references" : [ ],
-      "properties" : [ {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : false,
-        "name" : "group",
-        "description" : null,
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "name",
-        "description" : "Name of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "version",
-        "description" : "Version of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      } ],
-      "superType" : null
     },
     "org.eclipse.hawkbit:Url:1.0.0" : {
       "targetPlatformKey" : null,
@@ -2802,8 +2745,8 @@
       "references" : [ {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       } ],
       "properties" : [ {
         "targetPlatformKey" : null,
@@ -2827,8 +2770,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],

--- a/models/org.eclipse.hawkbit-SoftwareRemoveAction-2.0.0.type/model.datatype
+++ b/models/org.eclipse.hawkbit-SoftwareRemoveAction-2.0.0.type/model.datatype
@@ -3,7 +3,7 @@ namespace org.eclipse.hawkbit
 version 2.0.0
 displayname "SoftwareRemoveAction"
 description "Action instructing the device to remove a defined set of software."
-using org.eclipse.hawkbit.DependencyDescription;1.0.0
+using org.eclipse.hawkbit.DependencyDescription;2.0.0
 
 entity SoftwareRemoveAction {
   mandatory correlationId as string "An identifier used to correlate the status updates sent from the device for this action."

--- a/models/org.eclipse.hawkbit-SoftwareRemoveAction-2.0.0.type/model.json
+++ b/models/org.eclipse.hawkbit-SoftwareRemoveAction-2.0.0.type/model.json
@@ -6,7 +6,7 @@
     "prettyFormat" : "org.eclipse.hawkbit:SoftwareRemoveAction:2.0.0"
   },
   "models" : {
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
+    "org.eclipse.hawkbit:DependencyDescription:2.0.0" : {
       "targetPlatformKey" : null,
       "stereotypes" : [ ],
       "mappingReference" : null,
@@ -14,12 +14,12 @@
       "id" : {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       },
       "type" : "Datatype",
-      "displayName" : "SoftwareDescription",
-      "description" : "Describes a software installed on the device.",
+      "displayName" : "DependencyDescription",
+      "description" : "Describes an installed software or other dependencies for a device.",
       "category" : null,
       "fileName" : "DependencyDescription.type",
       "modelType" : "EntityModel",
@@ -28,9 +28,9 @@
         "targetPlatformKey" : null,
         "stereotypes" : [ ],
         "mappingReference" : null,
-        "mandatory" : false,
+        "mandatory" : true,
         "name" : "group",
-        "description" : null,
+        "description" : "Group name (e.g. vendor). This should be unique together with name.",
         "type" : "STRING",
         "constraints" : [ ],
         "attributes" : [ ],
@@ -42,7 +42,7 @@
         "mappingReference" : null,
         "mandatory" : true,
         "name" : "name",
-        "description" : "Name of the software.",
+        "description" : "Name of the software or hardware part.",
         "type" : "STRING",
         "constraints" : [ ],
         "attributes" : [ ],
@@ -54,7 +54,19 @@
         "mappingReference" : null,
         "mandatory" : true,
         "name" : "version",
-        "description" : "Version of the software.",
+        "description" : "Version or value uniquely identifying the software or hardware.",
+        "type" : "STRING",
+        "constraints" : [ ],
+        "attributes" : [ ],
+        "multiple" : false,
+        "primitive" : true
+      }, {
+        "targetPlatformKey" : null,
+        "stereotypes" : [ ],
+        "mappingReference" : null,
+        "mandatory" : false,
+        "name" : "type",
+        "description" : "An additional classification type, e.g. hw-part, docker, etc.",
         "type" : "STRING",
         "constraints" : [ ],
         "attributes" : [ ],
@@ -83,8 +95,8 @@
       "references" : [ {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       } ],
       "properties" : [ {
         "targetPlatformKey" : null,
@@ -108,8 +120,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],

--- a/models/org.eclipse.hawkbit.swupdatable-SoftwareUpdatable-2.0.0.fbmodel/model.json
+++ b/models/org.eclipse.hawkbit.swupdatable-SoftwareUpdatable-2.0.0.fbmodel/model.json
@@ -79,8 +79,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -100,8 +100,8 @@
           "value" : {
             "name" : "DependencyDescription",
             "namespace" : "org.eclipse.hawkbit",
-            "version" : "1.0.0",
-            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version" : "2.0.0",
+            "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "type" : "dictionary"
         },
@@ -487,63 +487,6 @@
           "prettyFormat" : "org.eclipse.hawkbit:Protocol:2.0.0"
         }
       } ]
-    },
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0" : {
-      "targetPlatformKey" : null,
-      "stereotypes" : [ ],
-      "mappingReference" : null,
-      "vortolang" : "1.0",
-      "id" : {
-        "name" : "DependencyDescription",
-        "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
-      },
-      "type" : "Datatype",
-      "displayName" : "SoftwareDescription",
-      "description" : "Describes a software installed on the device.",
-      "category" : null,
-      "fileName" : "DependencyDescription.type",
-      "modelType" : "EntityModel",
-      "references" : [ ],
-      "properties" : [ {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : false,
-        "name" : "group",
-        "description" : null,
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "name",
-        "description" : "Name of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      }, {
-        "targetPlatformKey" : null,
-        "stereotypes" : [ ],
-        "mappingReference" : null,
-        "mandatory" : true,
-        "name" : "version",
-        "description" : "Version of the software.",
-        "type" : "STRING",
-        "constraints" : [ ],
-        "attributes" : [ ],
-        "multiple" : false,
-        "primitive" : true
-      } ],
-      "superType" : null
     },
     "org.eclipse.hawkbit:Url:1.0.0" : {
       "targetPlatformKey" : null,
@@ -2139,8 +2082,8 @@
       "references" : [ {
         "name" : "DependencyDescription",
         "namespace" : "org.eclipse.hawkbit",
-        "version" : "1.0.0",
-        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+        "version" : "2.0.0",
+        "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
       } ],
       "properties" : [ {
         "targetPlatformKey" : null,
@@ -2164,8 +2107,8 @@
         "type" : {
           "name" : "DependencyDescription",
           "namespace" : "org.eclipse.hawkbit",
-          "version" : "1.0.0",
-          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version" : "2.0.0",
+          "prettyFormat" : "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         },
         "constraints" : [ ],
         "attributes" : [ ],

--- a/models/vorto.private.bosch.io.hrm.test-BsedNanoBeemes-1.0.2.infomodel/model.json
+++ b/models/vorto.private.bosch.io.hrm.test-BsedNanoBeemes-1.0.2.infomodel/model.json
@@ -140,8 +140,8 @@
             "value": {
               "name": "DependencyDescription",
               "namespace": "org.eclipse.hawkbit",
-              "version": "1.0.0",
-              "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+              "version": "2.0.0",
+              "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:2.0.0"
             },
             "type": "dictionary"
           },
@@ -162,8 +162,8 @@
             "value": {
               "name": "DependencyDescription",
               "namespace": "org.eclipse.hawkbit",
-              "version": "1.0.0",
-              "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+              "version": "2.0.0",
+              "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:2.0.0"
             },
             "type": "dictionary"
           },
@@ -458,8 +458,8 @@
           "type": {
             "name": "DependencyDescription",
             "namespace": "org.eclipse.hawkbit",
-            "version": "1.0.0",
-            "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version": "2.0.0",
+            "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "constraints": [],
           "attributes": [],
@@ -1127,67 +1127,6 @@
           }
         }
       ]
-    },
-    "org.eclipse.hawkbit:DependencyDescription:1.0.0": {
-      "targetPlatformKey": null,
-      "stereotypes": [],
-      "mappingReference": null,
-      "vortolang": "1.0",
-      "id": {
-        "name": "DependencyDescription",
-        "namespace": "org.eclipse.hawkbit",
-        "version": "1.0.0",
-        "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
-      },
-      "type": "Datatype",
-      "displayName": "SoftwareDescription",
-      "description": "Describes a software installed on the device.",
-      "category": null,
-      "fileName": "DependencyDescription.type",
-      "modelType": "EntityModel",
-      "references": [],
-      "properties": [
-        {
-          "targetPlatformKey": null,
-          "stereotypes": [],
-          "mappingReference": null,
-          "mandatory": false,
-          "name": "group",
-          "description": null,
-          "type": "STRING",
-          "constraints": [],
-          "attributes": [],
-          "multiple": false,
-          "primitive": true
-        },
-        {
-          "targetPlatformKey": null,
-          "stereotypes": [],
-          "mappingReference": null,
-          "mandatory": true,
-          "name": "name",
-          "description": "Name of the software.",
-          "type": "STRING",
-          "constraints": [],
-          "attributes": [],
-          "multiple": false,
-          "primitive": true
-        },
-        {
-          "targetPlatformKey": null,
-          "stereotypes": [],
-          "mappingReference": null,
-          "mandatory": true,
-          "name": "version",
-          "description": "Version of the software.",
-          "type": "STRING",
-          "constraints": [],
-          "attributes": [],
-          "multiple": false,
-          "primitive": true
-        }
-      ],
-      "superType": null
     },
     "vorto.private.bosch.io.hrm.test:BsedNanoBeemes:1.0.2": {
       "targetPlatformKey": null,
@@ -3014,8 +2953,8 @@
         {
           "name": "DependencyDescription",
           "namespace": "org.eclipse.hawkbit",
-          "version": "1.0.0",
-          "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+          "version": "2.0.0",
+          "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:2.0.0"
         }
       ],
       "properties": [
@@ -3042,8 +2981,8 @@
           "type": {
             "name": "DependencyDescription",
             "namespace": "org.eclipse.hawkbit",
-            "version": "1.0.0",
-            "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:1.0.0"
+            "version": "2.0.0",
+            "prettyFormat": "org.eclipse.hawkbit:DependencyDescription:2.0.0"
           },
           "constraints": [],
           "attributes": [],


### PR DESCRIPTION
The `SoftwareRemoveAction` model had the wrong dependency version defined for `DependencyDescription`. This resulted in generating the json representation with two versions of the model `DependencyDescription` in it