### PR TITLE
Change type of OperationStatus-2.0.0:statusCode property from String to int

### DIFF
--- a/models/org.eclipse.hawkbit-OperationStatus-2.0.0.type/model.datatype
+++ b/models/org.eclipse.hawkbit-OperationStatus-2.0.0.type/model.datatype
@@ -19,5 +19,5 @@ entity OperationStatus {
  optional progress as int with {
 		measurementUnit : org.eclipse.vorto.Unit.percent } <MIN 0 , MAX 100> "A progress indicator in percentage."
  optional message as string "Message from the device to give more context to the transmitted status."
- optional statusCode as string "Custom status code transmitted by the device."
+ optional statusCode as int "Custom status code transmitted by the device."
 }

--- a/models/org.eclipse.hawkbit-OperationStatus-2.0.0.type/model.json
+++ b/models/org.eclipse.hawkbit-OperationStatus-2.0.0.type/model.json
@@ -1031,8 +1031,14 @@
         "mandatory" : false,
         "name" : "statusCode",
         "description" : "Custom status code transmitted by the device.",
-        "type" : "STRING",
-        "constraints" : [ ],
+        "type" : "INT",
+        "constraints" : [ {
+          "type" : "MIN",
+          "value" : "-2147483648"
+        }, {
+          "type" : "MAX",
+          "value" : "2147483647"
+        } ],
         "attributes" : [ ],
         "multiple" : false,
         "primitive" : true


### PR DESCRIPTION
To better align the SoftwareUpdatable feature with Eclipse Hawkbit, we decided to change the type of the statusCode property in the OperationStatus-2.0.0 datatype from String to int.